### PR TITLE
Fix missing address field in pp

### DIFF
--- a/app/commands/decidim/participatory_processes/admin/create_participatory_process.rb
+++ b/app/commands/decidim/participatory_processes/admin/create_participatory_process.rb
@@ -65,7 +65,10 @@ module Decidim
             meta_scope: form.meta_scope,
             start_date: form.start_date,
             end_date: form.end_date,
-            participatory_process_group: form.participatory_process_group
+            participatory_process_group: form.participatory_process_group,
+            address: form.address,
+            latitude: form.latitude,
+            longitude: form.longitude
           )
 
           return process unless process.valid?

--- a/app/commands/decidim/participatory_processes/admin/update_participatory_process.rb
+++ b/app/commands/decidim/participatory_processes/admin/update_participatory_process.rb
@@ -77,7 +77,10 @@ module Decidim
             participatory_process_group: form.participatory_process_group,
             show_metrics: form.show_metrics,
             show_statistics: form.show_statistics,
-            announcement: form.announcement
+            announcement: form.announcement,
+            address: form.address,
+            latitude: form.latitude,
+            longitude: form.longitude
           }.merge(uploader_attributes)
         end
 

--- a/app/forms/decidim/participatory_processes/admin/participatory_process_form.rb
+++ b/app/forms/decidim/participatory_processes/admin/participatory_process_form.rb
@@ -24,6 +24,10 @@ module Decidim
         translatable_attribute :title, String
         translatable_attribute :target, String
 
+        attribute :address, String
+        attribute :latitude, Float
+        attribute :longitude, Float
+
         attribute :hashtag, String
         attribute :slug, String
 
@@ -50,6 +54,7 @@ module Decidim
 
         validates :area, presence: true, if: proc { |object| object.area_id.present? }
         validates :scope, presence: true, if: proc { |object| object.scope_id.present? }
+        validates :address, geocoding: true, if: ->(form) { form.address.present? }
         validates :slug, presence: true, format: { with: Decidim::ParticipatoryProcess.slug_format }
 
         validate :slug_uniqueness

--- a/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
+++ b/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
@@ -39,6 +39,13 @@
       <%= form.translated :editor, :announcement %>
       <p class="help-text"><%== t(".announcement_help") %></p>
     </div>
+
+    <% if Decidim.geocoder.present? %>
+      <div class="row column">
+        <%= form.text_field :address %>
+        <p class="help-text"><%== t(".address_help") %></p>
+      </div>
+    <% end %>
   </div>
 
   <div class="card-divider">

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -92,6 +92,7 @@ ignore_missing:
  - decidim.participatory_processes.show.*
  - decidim.participatory_process.show.*
  - decidim.pages.home.sub_hero.*
+ - decidim.participatory_processes.admin.participatory_processes.form.address_help
  - faker.*
 
 # Consider these keys used:

--- a/spec/commands/create_participatory_process_spec.rb
+++ b/spec/commands/create_participatory_process_spec.rb
@@ -12,6 +12,9 @@ module Decidim::ParticipatoryProcesses
     let(:area) { create :area, organization: organization }
     let(:current_user) { create :user, :admin, organization: organization }
     let(:errors) { double.as_null_object }
+    let(:address) { "Carrer Pare Llaurador 113, baixos, 08224 Terrassa" }
+    let(:latitude) { 40.1234 }
+    let(:longitude) { 2.1234 }
     let(:related_process_ids) { [] }
     let(:form) do
       instance_double(
@@ -44,10 +47,17 @@ module Decidim::ParticipatoryProcesses
         area: area,
         errors: errors,
         related_process_ids: related_process_ids,
-        participatory_process_group: participatory_process_group
+        participatory_process_group: participatory_process_group,
+        address: address,
+        latitude: latitude,
+        longitude: longitude
       )
     end
     let(:invalid) { false }
+
+    before do
+      stub_geocoding(address, [latitude, longitude])
+    end
 
     context "when the form is not valid" do
       let(:invalid) { true }


### PR DESCRIPTION
### Address field in PP

Add the address field in PP monkey patch


#### Original issue

`address` field is missing because of monkey patchs in app that override PP views from interactive map.

#### 📷 Screenshots
<img width="1255" alt="Screenshot 2021-05-03 at 14 21 21" src="https://user-images.githubusercontent.com/26109239/116875353-0dc46000-ac1b-11eb-9915-9ccc43da4b17.png">
