### PR TITLE
Delete related translations and invite config

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-# Use this hook to configure devise mailer, warden hooks and so forth.
-# Many of these configuration options can be set straight in your model.
-
-Devise.setup do |config|
-  config.invite_for = 1.month
-end

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -261,26 +261,6 @@ fr:
   devise:
     failure:
       invited: Invited
-    mailer:
-      invitation_instructions:
-        accept: Accepter l'invitation
-        accept_until: Cette invitation expirera le %{due_date}.
-        decline: Refuser l'invitation
-        hello: "%{email},"
-        ignore: |-
-          Si vous ne renouvelez pas votre inscription, votre compte sera automatiquement supprimé à compter du 29 juillet et toutes vos contributions passées deviendront anonymes.
-          <br /><br />
-          Pour toutes questions vous pouvez nous contacter sur <a href="mailto:jeparticipe@mairie-toulouse.fr">jeparticipe@mairie-toulouse.fr</a>.
-          <br />
-        invited_you_as_admin: "%{invited_by} vous a invité en tant qu'administrateur de %{application}. Vous pouvez accepter cette invitation grâce au lien ci-dessous."
-        invited_you_as_private_user: "%{invited_by} vous a invité en tant qu'utilisateur privé de %{application}. Vous pouvez l'accepter via le lien ci-dessous."
-        someone_invited_you: |-
-          La plateforme jeparticipe.toulouse.fr évolue !<br />
-          <br />
-          Afin de continuer à donner votre avis et de participer aux décisions qui font Toulouse, nous vous invitons à renouveler votre inscription en validant les nouvelles conditions générales d'utilisation et en complétant votre profil, en cliquant ici !
-        someone_invited_you_as_admin: Vous avez été invité en tant qu'administrateur de %{application}, vous pouvez l'accepter via le lien ci-dessous.
-        someone_invited_you_as_private_user: Vous avez été invité en tant qu'utilisateur privé de %{application}, vous pouvez l'accepter via le lien ci-dessous.
-        subject: Instructions d'invitation
     registrations:
       new:
         sign_up: S'inscrire


### PR DESCRIPTION
This PR aims to delete custom invitations translations and to delete the custom `config.invite_for = 1.month`