### PR TITLE
Fix migration proposals

### DIFF
--- a/db/migrate/20201126165641_move_proposals_fields_to_i18n.decidim_proposals.rb
+++ b/db/migrate/20201126165641_move_proposals_fields_to_i18n.decidim_proposals.rb
@@ -4,6 +4,8 @@
 
 class MoveProposalsFieldsToI18n < ActiveRecord::Migration[5.2]
   def up
+    puts "Skipping migration '20201126165641' - MoveProposalsFieldsToI18n"
+    return
     add_column :decidim_proposals_proposals, :new_title, :jsonb
     add_column :decidim_proposals_proposals, :new_body, :jsonb
 

--- a/db/migrate/20201126165641_move_proposals_fields_to_i18n.decidim_proposals.rb
+++ b/db/migrate/20201126165641_move_proposals_fields_to_i18n.decidim_proposals.rb
@@ -3,9 +3,10 @@
 # This migration comes from decidim_proposals (originally 20200708091228)
 
 class MoveProposalsFieldsToI18n < ActiveRecord::Migration[5.2]
+  # rubocop:disable Lint/UnreachableCode
   def up
-    puts "Skipping migration '20201126165641' - MoveProposalsFieldsToI18n"
     return
+
     add_column :decidim_proposals_proposals, :new_title, :jsonb
     add_column :decidim_proposals_proposals, :new_body, :jsonb
 
@@ -48,6 +49,7 @@ class MoveProposalsFieldsToI18n < ActiveRecord::Migration[5.2]
 
     reset_column_information
   end
+  # rubocop:enable Lint/UnreachableCode
 
   def down
     add_column :decidim_proposals_proposals, :new_title, :string

--- a/db/migrate/20201126165641_move_proposals_fields_to_i18n.decidim_proposals.rb
+++ b/db/migrate/20201126165641_move_proposals_fields_to_i18n.decidim_proposals.rb
@@ -3,10 +3,8 @@
 # This migration comes from decidim_proposals (originally 20200708091228)
 
 class MoveProposalsFieldsToI18n < ActiveRecord::Migration[5.2]
-  # rubocop:disable Lint/UnreachableCode
+  # rubocop:disable Metrics/PerceivedComplexity
   def up
-    return
-
     add_column :decidim_proposals_proposals, :new_title, :jsonb
     add_column :decidim_proposals_proposals, :new_body, :jsonb
 
@@ -24,12 +22,17 @@ class MoveProposalsFieldsToI18n < ActiveRecord::Migration[5.2]
                    I18n.default_locale.to_s
                  end
 
-        proposal.new_title = {
-          locale => proposal.title
-        }
-        proposal.new_body = {
-          locale => proposal.body
-        }
+        proposal.new_title = if proposal.title.is_a? String
+                               { locale => proposal.title }
+                             else
+                               proposal.title
+                             end
+
+        proposal.new_body = if proposal.title.is_a? String
+                              { locale => proposal.body }
+                            else
+                              proposal.body
+                            end
 
         # rubocop:disable Rails/SkipsModelValidations
         proposal.update_column("new_title", proposal.new_title)
@@ -49,7 +52,7 @@ class MoveProposalsFieldsToI18n < ActiveRecord::Migration[5.2]
 
     reset_column_information
   end
-  # rubocop:enable Lint/UnreachableCode
+  # rubocop:enable Metrics/PerceivedComplexity
 
   def down
     add_column :decidim_proposals_proposals, :new_title, :string


### PR DESCRIPTION
### Description

A migration has been run twice and created a nested hash in Proposal titles and bodies in Database. 

-  [x] Disable this migration to avoid running on production mode

Command to run in Dev environment : 
```
Decidim::Proposals::Proposal.all.each do |prop|
	if prop.title["fr"].is_a? Hash
		prop.title = prop.title["fr"]
	end
  
	if prop.body["fr"].is_a? Hash
		prop.body = prop.body["fr"]
	end

	prop.save! if prop.has_changes_to_save?
end
```