### PR TITLE
Fix - Account Language Selection || Fix language helper variable interpretation

### DIFF
--- a/app/views/decidim/account/show.html.erb
+++ b/app/views/decidim/account/show.html.erb
@@ -11,7 +11,7 @@
       <%= f.text_field :nickname %>
       <%= f.email_field :email %>
 
-      <% if Decidim.available_locales.size > 1 %>
+      <% if @account.organization.available_locales.size > 1 %>
       <%= f.collection_select(
             :locale,
             @account.organization.available_locales,

--- a/app/views/decidim/account/show.html.erb
+++ b/app/views/decidim/account/show.html.erb
@@ -1,0 +1,51 @@
+<% add_decidim_page_title(t("profile", scope: "layouts.decidim.user_menu")) %>
+<% content_for(:subtitle) { t("profile", scope: "layouts.decidim.user_menu") } %>
+
+<div class="row">
+  <%= decidim_form_for(@account, url: account_path, method: :put, html: { autocomplete: "off" }) do |f| %>
+
+    <div class="columns large-8 end">
+      <%= form_required_explanation %>
+
+      <%= f.text_field :name %>
+      <%= f.text_field :nickname %>
+      <%= f.email_field :email %>
+
+      <% if Decidim.available_locales.size > 1 %>
+      <%= f.collection_select(
+            :locale,
+            @account.organization.available_locales,
+            :to_s,
+            ->(locale) {locale_name(locale) }
+          ) %>
+        <% else %>
+        <%= f.collection_select(
+              :locale,
+              @account.organization.available_locales,
+              :to_s,
+              ->(locale) {locale_name(locale) },
+              {},
+            { disabled: true }
+            )
+        %>
+      <% end %>
+
+      <p class="help-text"><%= t(".available_locales_helper", organization_name:current_organization.name) %></p>
+
+      <% if @account.errors[:password].any? || @account.errors[:password_confirmation].any? %>
+        <%= render partial: "password_fields", locals: { form: f } %>
+      <% else %>
+        <% if current_organization.sign_in_enabled? %>
+          <p>
+            <button type="button" data-toggle="passwordChange" class="link change-password"><%= t ".change_password" %></button>
+          </p>
+          <div id="passwordChange" class="toggle-show" data-toggler=".is-expanded">
+            <%= render partial: "password_fields", locals: { form: f } %>
+          </div>
+        <% end %>
+      <% end %>
+
+      <%= f.submit t(".update_account") %>
+    </div>
+  <% end %>
+</div>

--- a/spec/system/account_spec.rb
+++ b/spec/system/account_spec.rb
@@ -3,7 +3,6 @@
 require "spec_helper"
 
 describe "Account", type: :system do
-  # let(:organization) { create(:organization, available_locales: %w(en)) }
   let(:user) { create(:user, :confirmed, password: password, password_confirmation: password) }
   let(:password) { "dqCFgjfDbC7dPbrv" }
   let(:organization) { user.organization }
@@ -40,21 +39,19 @@ describe "Account", type: :system do
     end
 
     describe "update locales" do
-      context "when the user has one locale" do
+      context "when the organization has one locale" do
+        let(:organization) { create(:organization, available_locales: ["en"]) }
+
         it "is not possible to change locales, #user_locale is disabled" do
-          if organization.available_locales.size === 1
-            expect(page).to have_css("#user_locale", text: "English")
-            expect(find("#user_locale")).to be_disabled
-          end
+          expect(page).to have_css("#user_locale", text: "English")
+          expect(find("#user_locale")).to be_disabled
         end
       end
 
-      context "when the user has more than one locale" do
+      context "when the organization has more than one locale" do
         it "shows the list of locales" do
-          if organization.available_locales.size > 1
-            find("#user_locale").click
-            expect(page).to have_css("option", count: organization.available_locales.size)
-          end
+          find("#user_locale").click
+          expect(page).to have_css("option", count: organization.available_locales.size)
         end
       end
     end
@@ -77,33 +74,22 @@ describe "Account", type: :system do
     end
 
     describe "updating locale" do
-      context "when the user has one locale" do
-        it "is not possible to change locales, #user_locale is disabled" do
-          if organization.available_locales.size == 1
-            expect(page).to have_css("#user_locale", text: "English")
-            expect(find("#user_locale")).to be_disabled
-          end
-        end
-      end
-
-      context "when the user has more than one locale" do
+      context "when the organization has more than one locale" do
         it "switches the locale to french" do
-          if organization.available_locales.size > 1
-            within "form.edit_user" do
-              find("#user_locale").click
-              find("option", text: "Français").select_option
-              find("*[type=submit]").click
-            end
-
-            within_flash_messages do
-              expect(page).to have_content("successfully")
-            end
-
-            within "#user_locale" do
-              expect(page).to have_content("Français")
-            end
-            expect(page).to have_css(".help-text", text: organization.name)
+          within "form.edit_user" do
+            find("#user_locale").click
+            find("option", text: "Français").select_option
+            find("*[type=submit]").click
           end
+
+          within_flash_messages do
+            expect(page).to have_content("successfully")
+          end
+
+          within "#user_locale" do
+            expect(page).to have_content("Français")
+          end
+          expect(page).to have_css(".help-text", text: organization.name)
         end
       end
     end

--- a/spec/system/account_spec.rb
+++ b/spec/system/account_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 describe "Account", type: :system do
+  # If you want to try with only one locale -> Comment line 10 and uncomment line 7
+  # let(:organization) { create(:organization, available_locales: %w(en)) }
   let(:user) { create(:user, :confirmed, password: password, password_confirmation: password) }
   let(:password) { "dqCFgjfDbC7dPbrv" }
   let(:organization) { user.organization }
@@ -38,11 +40,26 @@ describe "Account", type: :system do
       end
     end
 
+    describe "update locales" do
+      it "shows the list of locales" do
+        find("#user_locale").click
+        if organization.available_locales.size == 1
+          expect(page).to have_css("#user_locale", text: "English")
+          expect(find("#user_locale")).to be_disabled
+        else
+          expect(page).to have_css("option", count: organization.available_locales.size)
+        end
+      end
+    end
+
     describe "updating personal data" do
       it "updates the user's data" do
         within "form.edit_user" do
           fill_in :user_name, with: "Nikola Tesla"
-
+          if organization.available_locales.size > 1
+            find("#user_locale").click
+            find("option", text: "Français").select_option
+          end
           find("*[type=submit]").click
         end
 
@@ -52,6 +69,12 @@ describe "Account", type: :system do
 
         within ".title-bar" do
           expect(page).to have_content("Nikola Tesla")
+        end
+        if organization.available_locales.size > 1
+          within "#user_locale" do
+            expect(page).to have_content("Français")
+          end
+          expect(page).to have_css(".help-text", text: organization.name)
         end
       end
     end


### PR DESCRIPTION
Hello ! 

Here's a PR to correct the fact that if we had only one locale, dropdown was still active -> Now he's disabled if we only have one and work properly if we have some more.

Another thing was to add some tests and to correct the bug of %{organization_name} interpretation that was not done. Now fixed and work also properly.