### PR TITLE
[Fix] - assemblies order by weight in PP

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -542,6 +542,7 @@ GEM
     mime-types-data (3.2022.0105)
     mini_magick (4.11.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.8.0)
     minitest (5.16.3)
     mixlib-cli (2.1.8)
     mixlib-config (3.0.27)
@@ -554,6 +555,9 @@ GEM
     mustache (1.1.1)
     newrelic_rpm (8.10.0)
     nio4r (2.5.8)
+    nokogiri (1.13.8)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
     nokogiri (1.13.8-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.8-x86_64-linux)
@@ -863,6 +867,7 @@ GEM
     zeitwerk (2.6.0)
 
 PLATFORMS
+  ruby
   x86_64-darwin-20
   x86_64-linux
 

--- a/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
+++ b/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
@@ -50,11 +50,11 @@
         </div>
       <% end %>
 
-      <% if linked_assemblies.any?  && current_participatory_space.display_linked_assemblies %>
+      <% if current_participatory_space.display_linked_assemblies && linked_assemblies.any? %>
         <div class="section">
           <h4 class="section-heading"><%= t("participatory_process.show.related_assemblies", scope: "decidim") %></h4>
           <div class="row small-up-1 medium-up-2 card-grid">
-            <% linked_assemblies.each do |linked_assembly| %>
+            <% linked_assemblies.sort_by(&:weight).each do |linked_assembly| %>
               <%= card_for(linked_assembly) %>
             <% end %>
           </div>

--- a/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
+++ b/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
@@ -50,7 +50,7 @@
         </div>
       <% end %>
 
-      <% if current_participatory_space.display_linked_assemblies && linked_assemblies.any? %>
+      <% if linked_assemblies.any? %>
         <div class="section">
           <h4 class="section-heading"><%= t("participatory_process.show.related_assemblies", scope: "decidim") %></h4>
           <div class="row small-up-1 medium-up-2 card-grid">

--- a/spec/system/participatory_processes_spec.rb
+++ b/spec/system/participatory_processes_spec.rb
@@ -531,41 +531,6 @@ describe "Participatory Processes", type: :system do
             end
           end
         end
-
-        context "when assemblies are linked to participatory process" do
-          let!(:published_assembly) { create(:assembly, :published, organization: organization) }
-          let!(:unpublished_assembly) { create(:assembly, :unpublished, organization: organization) }
-          let!(:private_assembly) { create(:assembly, :published, :private, :opaque, organization: organization) }
-          let!(:transparent_assembly) { create(:assembly, :published, :private, :transparent, organization: organization) }
-
-          before do
-            published_assembly.link_participatory_space_resources(participatory_process, "included_participatory_processes")
-            unpublished_assembly.link_participatory_space_resources(participatory_process, "included_participatory_processes")
-            private_assembly.link_participatory_space_resources(participatory_process, "included_participatory_processes")
-            transparent_assembly.link_participatory_space_resources(participatory_process, "included_participatory_processes")
-            visit decidim_participatory_processes.participatory_process_path(participatory_process)
-          end
-
-          it "display related assemblies" do
-            expect(page).to have_content("RELATED ASSEMBLIES")
-            expect(page).to have_content(translated(published_assembly.title))
-            expect(page).to have_content(translated(transparent_assembly.title))
-            expect(page).to have_no_content(translated(unpublished_assembly.title))
-            expect(page).to have_no_content(translated(private_assembly.title))
-          end
-
-          context "when display_linked_assemblies is disabled" do
-            let(:display_linked_assemblies) { false }
-
-            it "doesn't display related assemblies" do
-              expect(page).to have_no_content("RELATED ASSEMBLIES")
-              expect(page).to have_no_content(translated(published_assembly.title))
-              expect(page).to have_no_content(translated(transparent_assembly.title))
-              expect(page).to have_no_content(translated(unpublished_assembly.title))
-              expect(page).to have_no_content(translated(private_assembly.title))
-            end
-          end
-        end
       end
     end
   end


### PR DESCRIPTION
#### Description

Ensure assemblies are sort by `weight` rather than title in highlighted PP