### PR TITLE
Fix - Fixing order of PP's in assemblies

### DIFF
--- a/app/controllers/decidim/assemblies/assemblies_controller.rb
+++ b/app/controllers/decidim/assemblies/assemblies_controller.rb
@@ -87,7 +87,7 @@ module Decidim
       # OSP : Customization reverse sort by start date
       def assembly_participatory_processes
         @assembly_participatory_processes ||= @current_participatory_space.linked_participatory_space_resources(:participatory_processes, "included_participatory_processes")
-                                                                          .order("start_date DESC")
+                                                                          .order(end_date: :desc, start_date: :asc)
       end
 
       def current_assemblies_settings

--- a/app/controllers/decidim/assemblies/assemblies_controller.rb
+++ b/app/controllers/decidim/assemblies/assemblies_controller.rb
@@ -86,8 +86,12 @@ module Decidim
 
       # OSP : Customization reverse sort by start date
       def assembly_participatory_processes
-        @assembly_participatory_processes ||= @current_participatory_space.linked_participatory_space_resources(:participatory_processes, "included_participatory_processes")
-                                                                          .order(end_date: :desc, start_date: :asc)
+        assembly_participatory_processes = @current_participatory_space.linked_participatory_space_resources(:participatory_processes, "included_participatory_processes")
+
+        sorted_by_end_date = assembly_participatory_processes.active_spaces.order(end_date: :asc)
+        sorted_by_end_date += assembly_participatory_processes.past_spaces.order(end_date: :desc)
+
+        @assembly_participatory_processes ||= sorted_by_end_date
       end
 
       def current_assemblies_settings

--- a/spec/controllers/assemblies_controller_spec.rb
+++ b/spec/controllers/assemblies_controller_spec.rb
@@ -114,7 +114,7 @@ module Decidim
           controller.instance_variable_set(:@current_participatory_space, current_participatory_space)
         end
 
-        it "includes only participatory processes related to the assembly, ordered by end_date: :desc, start_date: :asc" do
+        it "includes only participatory processes related to the assembly, first those which are active by end_date :asc, then inactive ones by end_date :desc" do
           sorted_participatory_processes = participatory_processes.select(&:active?).sort_by(&:end_date)
           sorted_participatory_processes += participatory_processes.select(&:past?).sort_by(&:end_date).reverse
 

--- a/spec/controllers/assemblies_controller_spec.rb
+++ b/spec/controllers/assemblies_controller_spec.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Assemblies
+    describe AssembliesController, type: :controller do
+      routes { Decidim::Assemblies::Engine.routes }
+
+      let(:organization) { create(:organization) }
+
+      let!(:unpublished_assembly) do
+        create(
+          :assembly,
+          :unpublished,
+          organization: organization
+        )
+      end
+
+      let!(:published) do
+        create(
+          :assembly,
+          :published,
+          organization: organization
+        )
+      end
+
+      let!(:promoted) do
+        create(
+          :assembly,
+          :published,
+          :promoted,
+          organization: organization
+        )
+      end
+
+      before do
+        request.env["decidim.current_organization"] = organization
+      end
+
+      describe "published_assemblies" do
+        context "when there are no published assemblies" do
+          before do
+            published.unpublish!
+            promoted.unpublish!
+          end
+
+          it "redirects to 404" do
+            expect { get :index }.to raise_error(ActionController::RoutingError)
+          end
+        end
+      end
+
+      describe "GET assemblies in json format" do
+        let!(:first_level) { create(:assembly, :published, :with_parent, parent: published, organization: organization) }
+        let!(:second_level) { create(:assembly, :published, :with_parent, parent: first_level, organization: organization) }
+        let!(:third_level) { create(:assembly, :published, :with_parent, parent: second_level, organization: organization) }
+
+        let(:parsed_response) { JSON.parse(response.body, symbolize_names: true) }
+
+        it "includes only published assemblies with their children (two levels)" do
+          get :index, format: :json
+          expect(parsed_response).to match_array(
+            [
+              {
+                name: translated(promoted.title),
+                children: []
+              },
+              {
+                name: translated(published.title),
+                children: [
+                  {
+                    name: translated(first_level.title),
+                    children: [{ name: translated(second_level.title) }]
+                  }
+                ]
+              }
+            ]
+          )
+        end
+      end
+
+      describe "promoted_assemblies" do
+        it "includes only promoted" do
+          expect(controller.helpers.promoted_assemblies).to contain_exactly(promoted)
+        end
+      end
+
+      describe "parent_assemblies" do
+        let!(:child_assembly) { create(:assembly, parent: published, organization: organization) }
+
+        it "includes only parent assemblies, with promoted listed first" do
+          expect(controller.helpers.parent_assemblies.first).to eq(promoted)
+          expect(controller.helpers.parent_assemblies.second).to eq(published)
+        end
+      end
+
+      describe "assembly_participatory_processes" do
+        let!(:participatory_processes) do
+          5.times.map do
+            create(
+              :participatory_process,
+              :published,
+              organization: organization,
+              start_date: Time.zone.now - rand(1..3).days,
+              end_date: Time.zone.now + rand(1..3).days
+            )
+          end
+        end
+
+        before do
+          published.link_participatory_space_resources(participatory_processes, "included_participatory_processes")
+          current_participatory_space = published
+          controller.instance_variable_set(:@current_participatory_space, current_participatory_space)
+        end
+
+        it "includes only participatory processes related to the assembly, ordered by end_date: :desc, start_date: :asc" do
+          sorted_participatory_processes = participatory_processes.select(&:active?).sort_by(&:end_date)
+          sorted_participatory_processes += participatory_processes.select(&:past?).sort_by(&:end_date).reverse
+
+          expect(controller.helpers.assembly_participatory_processes.map(&:id)).to eq(sorted_participatory_processes.map(&:id))
+        end
+      end
+
+      describe "GET show" do
+        context "when the assembly is unpublished" do
+          it "redirects to sign in path" do
+            get :show, params: { slug: unpublished_assembly.slug }
+
+            expect(response).to redirect_to("/users/sign_in")
+          end
+
+          context "with signed in user" do
+            let!(:user) { create(:user, :confirmed, organization: organization) }
+
+            before do
+              sign_in user, scope: :user
+            end
+
+            it "redirects to root path" do
+              get :show, params: { slug: unpublished_assembly.slug }
+
+              expect(response).to redirect_to("/")
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hello ! I made a PR to fix a bug on assemblies concerning ordering of Participatory Processes related to it.

Now it follows this rule -> Firstly by ending date -> The later it ends, the more it will appear first
Then in this first order , order it by the starting date -> The earlier it was created,  the more it will appear first in this second ordering.

Hoping that will work properly, if you have any problem feel free to tell me about it.