### PR TITLE
fix unpublished meetings

### DIFF
--- a/config/initializers/decidim_meetings.rb
+++ b/config/initializers/decidim_meetings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.configuration.to_prepare do
   Decidim.view_hooks.send(:hooks).delete(:upcoming_meeting_for_card)
   Decidim.view_hooks.register(:upcoming_meeting_for_card, priority: Decidim::ViewHooks::LOW_PRIORITY) do |view_context|

--- a/config/initializers/decidim_meetings.rb
+++ b/config/initializers/decidim_meetings.rb
@@ -1,0 +1,16 @@
+Rails.configuration.to_prepare do
+  Decidim.view_hooks.send(:hooks).delete(:upcoming_meeting_for_card)
+  Decidim.view_hooks.register(:upcoming_meeting_for_card, priority: Decidim::ViewHooks::LOW_PRIORITY) do |view_context|
+    published_components = Decidim::Component.where(participatory_space: view_context.current_participatory_space).published
+    upcoming_meeting = Decidim::Meetings::Meeting.where(component: published_components).published.upcoming.order(:start_time, :end_time).first
+
+    next unless upcoming_meeting
+
+    view_context.render(
+      partial: "decidim/participatory_spaces/upcoming_meeting_for_card.html",
+      locals: {
+        upcoming_meeting: upcoming_meeting
+      }
+    )
+  end
+end

--- a/spec/system/upcoming_meeting_for_card_view_hooks_spec.rb
+++ b/spec/system/upcoming_meeting_for_card_view_hooks_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Upcoming meeting for card view hook", type: :system do
+  include_context "with a component" do
+    let(:participatory_space) { assembly }
+  end
+
+  let(:assembly) { create :assembly, organization: organization }
+  let(:manifest_name) { "meetings" }
+  let!(:past_meeting) do
+    create(:meeting, :published, :past, component: component)
+  end
+
+  context "when there are only past meetings" do
+    it "doesn't show any meeting" do
+      visit decidim_assemblies.assemblies_path
+
+      within "#assembly_#{assembly.id}" do
+        expect(page).to have_no_selector(".card__icondata")
+      end
+    end
+  end
+
+  context "when there are some upcoming meetings" do
+    let(:start_time) { Time.find_zone("UTC").local(2099, 5, 31, 12, 34) }
+    let!(:upcoming_meeting1) do
+      create(:meeting, :published, :upcoming, start_time: start_time, end_time: start_time + 1.hour, component: component)
+    end
+    let!(:upcoming_meeting2) do
+      create(:meeting, :published, :upcoming, start_time: start_time + 1.year, end_time: start_time + 1.year + 1.hour, component: component)
+    end
+
+    it "shows the next upcoming meeting" do
+      visit decidim_assemblies.assemblies_path
+
+      within "#assembly_#{assembly.id}" do
+        expect(page).to have_selector(".card__icondata")
+
+        within ".card__icondata" do
+          expect(page).to have_text("31 MAY 2099")
+          expect(page).to have_text("12:34")
+          expect(page).to have_text("13:34")
+        end
+      end
+    end
+
+    context "when there are some upcoming meetings and some are unpublished" do
+      let!(:upcoming_meeting1) do
+        create(:meeting, :upcoming, start_time: start_time, end_time: start_time + 1.hour, component: component)
+      end
+
+      it "shows the next published upcoming meeting" do
+        visit decidim_assemblies.assemblies_path
+
+        within "#assembly_#{assembly.id}" do
+          expect(page).to have_selector(".card__icondata")
+
+          within ".card__icondata" do
+            expect(page).to have_text("31 MAY 2100")
+            expect(page).to have_text("12:34")
+            expect(page).to have_text("13:34")
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
🎩 Description

This PR remove the following bug : when a meeting unpublished is the next one for an assembly, it is displayed in the linked assembly card in the participatory process linked

📌 Related Issues

[Notion card](https://www.notion.so/opensourcepolitics/bd4bf860eab94f9daca7da803f09e3b2?v=7606b488c3fc4986a954ab5cdf57ed33&p=c6701d2ccdfc4f2684fcabcf8c633faa&pm=c)

Testing

Describe the best way to test or validate your PR.

Example:

1. Link an assembly and a pp
2. Create a meeting closer to the others in the assembly
3. See it is not displayed in the pp page
