### PR TITLE
remove validations

### DIFF
--- a/OVERLOADS.md
+++ b/OVERLOADS.md
@@ -46,3 +46,7 @@ de6d804 - fix multipart object tagging (#40) (#41), 2021-12-24
 
 * `lib/tasks/restore_dump.rake`
 705e0ad - Run rubocop, 2021-12-01
+
+## Remove validations
+* `app/forms/decidim/decidim_awesome/proposals/proposal_wizard_create_step_form_override.rb`
+* `app/validators/etiquette_validator.rb`

--- a/app/forms/decidim/decidim_awesome/proposals/proposal_wizard_create_step_form_override.rb
+++ b/app/forms/decidim/decidim_awesome/proposals/proposal_wizard_create_step_form_override.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Recreate validations to take into account custom fields and ignore the length limit in proposals
+module Decidim
+  module DecidimAwesome
+    module Proposals
+      module ProposalWizardCreateStepFormOverride
+        extend ActiveSupport::Concern
+
+        included do
+          clear_validators!
+
+          validates :title, presence: true, etiquette: true
+          validates :title, length: { maximum: 150 }
+          validates :body, presence: true, etiquette: true, unless: ->(form) { form.override_validations? }
+          validates :body, proposal_length: {
+            minimum: 15,
+            maximum: ->(record) { record.override_validations? ? 0 : record.component.settings.proposal_length }
+          }
+
+          validate :body_is_not_bare_template, unless: ->(form) { form.override_validations? }
+
+          def override_validations?
+            return false if context.current_component.settings.participatory_texts_enabled
+
+            custom_fields.present?
+          end
+
+          def custom_fields
+            awesome_config = Decidim::DecidimAwesome::Config.new(context.current_organization)
+            awesome_config.context_from_component(context.current_component)
+            awesome_config.collect_sub_configs_values("proposal_custom_field")
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/validators/etiquette_validator.rb
+++ b/app/validators/etiquette_validator.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# This validator takes care of ensuring the validated content is
+# respectful, doesn't use caps, and overall is meaningful.
+class EtiquetteValidator < ActiveModel::EachValidator
+  IGNORE_FOR_CAPS = [:title].freeze
+
+  def validate_each(record, attribute, value)
+    return if value.blank?
+
+    validate_caps(record, attribute, value)
+    validate_marks(record, attribute, value)
+    validate_caps_first(record, attribute, value)
+  end
+
+  private
+
+  def validate_caps(record, attribute, value)
+    return if IGNORE_FOR_CAPS.include?(attribute)
+    return if value.scan(/[A-Z]/).length < value.length / 4
+
+    record.errors.add(attribute, options[:message] || :too_much_caps)
+  end
+
+  def validate_marks(record, attribute, value)
+    return if value.scan(/[!?¡¿]{2,}/).empty?
+
+    record.errors.add(attribute, options[:message] || :too_many_marks)
+  end
+
+  def validate_caps_first(record, attribute, value)
+    return if value.scan(/\A[a-z]{1}/).empty?
+
+    record.errors.add(attribute, options[:message] || :must_start_with_caps)
+  end
+end

--- a/spec/forms/proposal_wizard_create_step_form_spec.rb
+++ b/spec/forms/proposal_wizard_create_step_form_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Proposals
+    describe ProposalWizardCreateStepForm do
+      subject { form }
+
+      let(:params) do
+        {
+          title: title,
+          body: body,
+          body_template: body_template,
+          user_group_id: user_group.id
+        }
+      end
+
+      let(:organization) { create(:organization, available_locales: [:en]) }
+      let(:participatory_space) { create(:participatory_process, :with_steps, organization: organization) }
+      let(:component) { create(:proposal_component, participatory_space: participatory_space) }
+      let(:title) { "More sidewalks and less roads" }
+      let(:body) { "Cities need more people, not more cars" }
+      let(:body_template) { nil }
+      let(:author) { create(:user, organization: organization) }
+      let(:user_group) { create(:user_group, :verified, users: [author], organization: organization) }
+
+      let(:form) do
+        described_class.from_params(params).with_context(
+          current_component: component,
+          current_organization: component.organization,
+          current_participatory_space: participatory_space
+        )
+      end
+
+      context "when everything is OK" do
+        it { is_expected.to be_valid }
+      end
+
+      context "when there's no title" do
+        let(:title) { nil }
+
+        it { is_expected.to be_invalid }
+
+        it "only adds errors to this field" do
+          subject.valid?
+          expect(subject.errors.keys).to eq [:title]
+        end
+      end
+
+      context "when there's a title with too much caps" do
+        let(:title) { "THIS IS A TITLE WITH TOO MUCH CAPS" }
+
+        it { is_expected.to be_valid }
+      end
+
+      context "when there's a title too short" do
+        let(:title) { "A" }
+
+        it { is_expected.to be_valid }
+      end
+
+      context "when there's no body" do
+        let(:body) { nil }
+
+        it { is_expected.to be_invalid }
+      end
+
+      context "when the body exceeds the permited length" do
+        let(:component) { create(:proposal_component, :with_proposal_length, participatory_space: participatory_space, proposal_length: allowed_length) }
+        let(:allowed_length) { 15 }
+        let(:body) { "A body longer than the permitted" }
+
+        it { is_expected.to be_invalid }
+
+        context "with carriage return characters that cause it to exceed" do
+          let(:allowed_length) { 80 }
+          let(:body) { "This text is just the correct length\r\nwith the carriage return characters removed" }
+
+          it { is_expected.to be_valid }
+        end
+      end
+
+      context "when there's a body template set" do
+        let(:body_template) { "This is the template" }
+
+        it { is_expected.to be_valid }
+
+        context "when the template and the body are the same" do
+          let(:body) { body_template }
+
+          it { is_expected.to be_invalid }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

This PR removes two validation concerning the creation of a proposal :
 - The minimum length (previously 15, now none)
 - The pourcentage of capital letters (previously <25%, now none)

This PR overrides an awesome file because the validation is defined in this file.

#### :pushpin: Related Issues
*Link your PR to an issue*
- [Notion card](https://www.notion.so/opensourcepolitics/bd4bf860eab94f9daca7da803f09e3b2?v=c96df65755dd403d95e86f82d7749709&p=58e8880afd0a4183896ddfadc2db2bc9&pm=c)

#### Testing
*Describe the best way to test or validate your PR.*

Example:
- Go to the creation page of a proposal
- See there's no minimum length displayed
- Try creating a proposal with a title with less than 15 characters
- See it works
- Try creating a proposal with a title in full caps
- See it works

#### Tasks
- [x] Add specs
- [x] Add note about overrides in OVERLOADS.md

