### PR TITLE
[Fix] Subscopes Order Tags in Accountability Page

### DIFF
--- a/app/views/decidim/accountability/results/_scope_filters.html.erb
+++ b/app/views/decidim/accountability/results/_scope_filters.html.erb
@@ -1,0 +1,31 @@
+<div class="scope-filters section">
+  <% if current_component.has_subscopes? %>
+    <div><%= t("results.filters.scopes", scope: "decidim.accountability") %></div>
+
+    <ul class="tags tags--action">
+      <li <%= active_class_if_current(nil) %>>
+        <%= link_to url_for(filter: { category_id: category.try(:id) }) do %>
+          <span class="show-for-sr"><%= Decidim::Scope.model_name.human(count: 2) %></span>
+          <%= t("results.filters.all", scope: "decidim.accountability") %>
+        <% end %>
+      </li>
+
+      <% if current_participatory_space.scope %>
+        <li <%= active_class_if_current(current_participatory_space.scope.id) %>>
+          <%= link_to url_for(filter: { scope_id: current_participatory_space.scope.id, category_id: category.try(:id) }) do %>
+            <span class="show-for-sr"><%= Decidim::Scope.model_name.human(count: 1) %></span>
+            <%= translated_attribute(current_participatory_space.scope.name) %>
+          <% end %>
+        </li>
+      <% end %>
+      <% sorted_subscopes.each do |scope| %>
+        <li <%= active_class_if_current(scope.id) %>>
+          <%= link_to url_for(filter: { scope_id: scope.id, category_id: category.try(:id) }) do %>
+            <span class="show-for-sr"><%= Decidim::Scope.model_name.human(count: 1) %></span>
+            <%= translated_attribute(scope.name) %>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+</div>

--- a/config/initializers/extends.rb
+++ b/config/initializers/extends.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "extends/controllers/decidim/meetings/meetings_controller_extends"
+require "extends/helpers/decidim/accountability/application_helper_extends"
 
 def load_dir(directory)
   files = Dir.glob("lib/extends/#{directory}/*.rb")

--- a/lib/extends/helpers/decidim/accountability/application_helper_extends.rb
+++ b/lib/extends/helpers/decidim/accountability/application_helper_extends.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Accountability
+    module ApplicationHelperExtends
+      def sorted_subscopes
+        @sorted_subscopes ||= current_participatory_space.subscopes.sort_by { |subscope| subscope.name.values.first.split.first }
+      end
+    end
+  end
+end
+
+Decidim::Accountability::ApplicationHelper.module_eval do
+  prepend(Decidim::Accountability::ApplicationHelperExtends)
+end


### PR DESCRIPTION
#### :tophat: Description

This code is supposed to fix the order in the accountability page, scopes that were alone were well sorted numerically but when the scope had children, children were not sorted

🚨 - It seems that we had multiple issues related to this sort, maybe this could be an issue to report directly to decidim and think of a global fix

#### :pushpin: Related Issues

- Related to [Notion](https://www.notion.so/opensourcepolitics/Toulouse-fix-ordre-des-quartiers-dans-suivi-61f9fedac37f479797883fe330c6157d?pvs=4)

#### Testing

* Log in as admin
* Access Backoffice
* Go to settings and go to a "scope group"
* Add some scopes (alphanumerically compatible (ex : 1.0 Toulouse)
* Go to concertations settings
* Select one and link it to your scope group
* Go back to your concertation page in front office
* Click on the Accountability page 
* Check if the scopes you changed are well sorted alphanumerically as it should be