### PR TITLE
[Fix] - OpenData Failing Job

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,6 @@ group :production do
   gem "sentry-rails"
   gem "sentry-ruby"
   gem "sentry-sidekiq"
-  gem "sidekiq", "6.4.2"
+  gem "sidekiq", "7.0.7"
   gem "sidekiq-scheduler"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -702,6 +702,8 @@ GEM
       wisper (>= 1.6.1)
     redcarpet (3.6.0)
     redis (4.8.1)
+    redis-client (0.14.0)
+      connection_pool
     redlock (1.3.2)
       redis (>= 3.0.0, < 6.0)
     regexp_parser (2.7.0)
@@ -794,10 +796,11 @@ GEM
       sentry-ruby (~> 5.8.0)
       sidekiq (>= 3.0)
     seven_zip_ruby (1.3.0)
-    sidekiq (6.4.2)
-      connection_pool (>= 2.2.2)
-      rack (~> 2.0)
-      redis (>= 4.2.0)
+    sidekiq (7.0.7)
+      concurrent-ruby (< 2)
+      connection_pool (>= 2.3.0)
+      rack (>= 2.2.4)
+      redis-client (>= 0.11.0)
     sidekiq-scheduler (5.0.2)
       rufus-scheduler (~> 3.2)
       sidekiq (>= 6, < 8)
@@ -923,7 +926,7 @@ DEPENDENCIES
   sentry-rails
   sentry-ruby
   sentry-sidekiq
-  sidekiq (= 6.4.2)
+  sidekiq (= 7.0.7)
   sidekiq-scheduler
   spring (~> 2.0)
   spring-watcher-listen (~> 2.0)

--- a/app/jobs/decidim/open_data_job.rb
+++ b/app/jobs/decidim/open_data_job.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Decidim
+  class OpenDataJob < ApplicationJob
+    queue_as :low
+
+    def perform(organization)
+      return unless organization.is_a?(Decidim::Organization)
+
+      path = Rails.root.join("tmp/#{organization.open_data_file_path}")
+
+      exporter = OpenDataExporter.new(organization, path)
+      raise "Couldn't generate Open Data export" unless exporter.export.positive?
+
+      organization.open_data_file.attach(io: File.open(path, "rb"), filename: organization.open_data_file_path)
+    end
+  end
+end

--- a/app/jobs/decidim/open_data_job.rb
+++ b/app/jobs/decidim/open_data_job.rb
@@ -5,8 +5,6 @@ module Decidim
     queue_as :low
 
     def perform(organization)
-      return unless organization.is_a?(Decidim::Organization)
-
       path = Rails.root.join("tmp/#{organization.open_data_file_path}")
 
       exporter = OpenDataExporter.new(organization, path)

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -10,6 +10,7 @@
   - user_report
   - block_user
   - scheduled
+  - low
 
 :scheduler:
   :schedule:
@@ -26,7 +27,7 @@
       class: CalculateAllMetricsJob
       queue: scheduled
     PreloadOpenData:
-      cron: '0 0 1 * * *' # Run at 01:00
+      cron: '0 1 * * *' # Run at 01:00
       class: PreloadOpenDataJob
       queue: scheduled
     Backup:

--- a/lib/extends/exporters/proposal_serializer.rb
+++ b/lib/extends/exporters/proposal_serializer.rb
@@ -71,15 +71,15 @@ module ProposalSerializerExtend
   def creator_phone_number
     return "" if proposal.creator_identity.blank?
 
-    phone_number(proposal.creator_identity.try(:user_id)) || ""
+    return "" if proposal.creator_identity.try(:user_id).blank?
+
+    phone_number(proposal.creator_identity.try(:user_id))
   end
 
   # phone_number retrieve the phone number of an user stored from phone_authorization_handler
   # Param: user_id : Integer
   # Return string, empty or with the phone number
   def phone_number(user_id)
-    return "" if user_id.blank?
-
     authorization = Decidim::Authorization.where(name: "phone_authorization_handler", decidim_user_id: user_id)
     return "" if authorization.blank?
 

--- a/lib/extends/exporters/proposal_serializer.rb
+++ b/lib/extends/exporters/proposal_serializer.rb
@@ -3,13 +3,12 @@
 # Overrides Decidim::Proposals::ProposalSerializer
 module ProposalSerializerExtend
   # Public: Exports a hash with the serialized data for this proposal.
-  # rubocop:disable Metrics/CyclomaticComplexity
   def serialize
     {
       t_column_name(:id) => proposal.id,
-      t_column_name(:username) => proposal.creator_identity&.user_name || "",
-      t_column_name(:email) => proposal.creator_identity&.email || "",
-      t_column_name(:phone_number) => phone_number(proposal.creator_identity&.id),
+      t_column_name(:username) => creator_username,
+      t_column_name(:email) => creator_email,
+      t_column_name(:phone_number) => creator_phone_number,
       t_column_name(:category, ".category") => {
         t_column_name(:id, ".category") => proposal.category.try(:id),
         t_column_name(:name, ".category") => proposal.category.try(:name) || empty_translatable
@@ -50,7 +49,6 @@ module ProposalSerializerExtend
       }
     }
   end
-  # rubocop:enable Metrics/CyclomaticComplexity
 
   protected
 
@@ -58,10 +56,30 @@ module ProposalSerializerExtend
     "decidim.proposals.admin.exports.column_name.proposal"
   end
 
+  def creator_username
+    return "" if proposal.creator_identity.blank?
+
+    proposal.creator_identity.try(:user_name).presence || proposal.creator_identity.try(:name).presence || ""
+  end
+
+  def creator_email
+    return "" if proposal.creator_identity.blank?
+
+    proposal.creator_identity.try(:email).presence || ""
+  end
+
+  def creator_phone_number
+    return "" if proposal.creator_identity.blank?
+
+    phone_number(proposal.creator_identity.try(:user_id)) || ""
+  end
+
   # phone_number retrieve the phone number of an user stored from phone_authorization_handler
   # Param: user_id : Integer
   # Return string, empty or with the phone number
   def phone_number(user_id)
+    return "" if user_id.blank?
+
     authorization = Decidim::Authorization.where(name: "phone_authorization_handler", decidim_user_id: user_id)
     return "" if authorization.blank?
 

--- a/spec/services/decidim/proposals/proposal_serializer_spec.rb
+++ b/spec/services/decidim/proposals/proposal_serializer_spec.rb
@@ -154,6 +154,16 @@ module Decidim
             expect(serialized).to include("Answer" => expected_answer)
           end
         end
+
+        context "when author is an organization" do
+          let!(:proposal) { create(:proposal, :accepted, :official) }
+
+          it "serializes the author data" do
+            expect(serialized).to include("Username" => proposal.creator_identity&.name)
+            expect(serialized).to include("Email" => "")
+            expect(serialized).to include("Phone number" => "")
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
#### 🎩 Description

This PR is made to fix the OpenDataJob that was crashing if the author of a proposal was an organization because of the overriding of the serializer.

### 📌 Related Issues

Related to [Notion](https://www.notion.so/opensourcepolitics/Toulouse-OpenDataJob-fails-and-blocks-exports-queue-f926e55a82e347eba4cd0dd5f29dce89?pvs=4)

### 📝 What has been done

- Fix Serializer
- Change queue of the job
- Add some specs
- Rewrite the cron to match the format of a normal cron task
- Bump Sidekiq to v7.0.7 (latest version)