### PR TITLE
[Fix] - Participatory processes images not displayed

### DIFF
--- a/app/views/decidim/participatory_processes/participatory_processes/_promoted_process.html.erb
+++ b/app/views/decidim/participatory_processes/participatory_processes/_promoted_process.html.erb
@@ -24,7 +24,7 @@
         <%= link_to participatory_process_path(promoted_process), class: "card__link" do %>
           <h2 class="card__title"><%= decidim_html_escape(translated_attribute(promoted_process.title)).html_safe %></h2>
         <% end %>
-        <%= decidim_sanitize_editor html_truncate(translated_attribute(promoted_process.short_description), length: 630, separator: "...") %>
+        <%= decidim_sanitize_editor_admin html_truncate(translated_attribute(promoted_process.short_description), length: 630, separator: "...") %>
         <%= link_to participatory_process_path(promoted_process), class: "button small hollow card__button" do %>
           <span class="show-for-sr"><%= decidim_html_escape(translated_attribute(promoted_process.title)) %></span>
           <%= t("participatory_processes.promoted_process.more_info", scope: "layouts.decidim") %>

--- a/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
+++ b/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
@@ -32,9 +32,9 @@
           <%= render partial: "participatory_process_group" %>
         <% end %>
         <div class="lead">
-          <%= decidim_sanitize_editor translated_attribute(current_participatory_space.short_description) %>
+          <%= decidim_sanitize_editor_admin translated_attribute(current_participatory_space.short_description) %>
         </div>
-        <%= decidim_sanitize_editor translated_attribute(current_participatory_space.description) %>
+        <%= decidim_sanitize_editor_admin translated_attribute(current_participatory_space.description) %>
       </div>
       <%= attachments_for current_participatory_space %>
       <%= render_hook(:participatory_space_highlighted_elements) %>

--- a/spec/commands/decidim/create_participatory_process_spec.rb
+++ b/spec/commands/decidim/create_participatory_process_spec.rb
@@ -90,7 +90,7 @@ module Decidim::ParticipatoryProcesses
       end
 
       before do
-        expect(Decidim::ParticipatoryProcess).to receive(:new).and_return(invalid_process)
+        allow(Decidim::ParticipatoryProcess).to receive(:new).and_return(invalid_process)
       end
 
       it "broadcasts invalid" do

--- a/spec/commands/decidim/create_registration_spec.rb
+++ b/spec/commands/decidim/create_registration_spec.rb
@@ -106,7 +106,7 @@ module Decidim
 
         describe "when the form is not valid" do
           before do
-            expect(form).to receive(:invalid?).and_return(true)
+            allow(form).to receive(:invalid?).and_return(true)
           end
 
           it "broadcasts invalid" do

--- a/spec/commands/decidim/update_participatory_process_spec.rb
+++ b/spec/commands/decidim/update_participatory_process_spec.rb
@@ -58,7 +58,7 @@ module Decidim::ParticipatoryProcesses
 
       describe "when the form is not valid" do
         before do
-          expect(form).to receive(:invalid?).and_return(true)
+          allow(form).to receive(:invalid?).and_return(true)
         end
 
         it "broadcasts invalid" do
@@ -75,7 +75,7 @@ module Decidim::ParticipatoryProcesses
 
       describe "when the participatory process is not valid" do
         before do
-          expect(form).to receive(:invalid?).and_return(false)
+          allow(form).to receive(:invalid?).and_return(false)
           expect(my_process).to receive(:valid?).at_least(:once).and_return(false)
           my_process.errors.add(:hero_image, "Image too big")
           my_process.errors.add(:banner_image, "Image too big")

--- a/spec/system/participatory_processes_spec.rb
+++ b/spec/system/participatory_processes_spec.rb
@@ -407,6 +407,32 @@ describe "Participatory Processes", type: :system do
           end
         end
 
+        context "when the process contains images" do
+          let(:base_process) do
+            create(
+              :participatory_process,
+              :active,
+              organization: organization,
+              description: {
+                "en" => "<p>Process's content</p><img src=\"#{image_url}\" /><iframe src=\"#{image_url}\"></iframe>",
+                "ca" => "<p>Contingut de l'enquesta</p><img src=\"#{image_url}\" /><iframe src=\"#{image_url}\"></iframe>",
+                "es" => "<p>Contenido de la encuesta</p><img src=\"#{image_url}\" /><iframe src=\"#{image_url}\"></iframe>"
+              },
+              short_description: { en: "Short description", ca: "Descripció curta", es: "Descripción corta" },
+              show_metrics: show_metrics,
+              show_statistics: show_statistics,
+              display_linked_assemblies: display_linked_assemblies
+            )
+          end
+          let(:image_url) { "https://decidim.org/assets/decidim/logo-2x-1b6d1f7f7d3f5d7d3f5d7d3f5d7d3f5d7d3f5d7d3f5d7d3f5d7d3f5d7d3f5d.png" }
+
+          it "shows image" do
+            visit decidim_participatory_processes.participatory_process_path(participatory_process)
+            expect(page).to have_selector("img[src='#{image_url}']")
+            expect(page).to have_selector("iframe[src='#{image_url}']")
+          end
+        end
+
         it_behaves_like "has attachments" do
           let(:attached_to) { participatory_process }
         end

--- a/spec/system/participatory_processes_spec.rb
+++ b/spec/system/participatory_processes_spec.rb
@@ -414,9 +414,9 @@ describe "Participatory Processes", type: :system do
               :active,
               organization: organization,
               description: {
-                "en" => "<p>Process's content</p><img src=\"#{image_url}\" /><iframe src=\"#{image_url}\"></iframe>",
-                "ca" => "<p>Contingut de l'enquesta</p><img src=\"#{image_url}\" /><iframe src=\"#{image_url}\"></iframe>",
-                "es" => "<p>Contenido de la encuesta</p><img src=\"#{image_url}\" /><iframe src=\"#{image_url}\"></iframe>"
+                "en" => "<p>Description</p><img src=\"#{image_url}\" /><iframe src=\"#{image_url}\"></iframe>",
+                "ca" => "<p>Descripció</p><img src=\"#{image_url}\" /><iframe src=\"#{image_url}\"></iframe>",
+                "es" => "<p>Descripción</p><img src=\"#{image_url}\" /><iframe src=\"#{image_url}\"></iframe>"
               },
               short_description: { en: "Short description", ca: "Descripció curta", es: "Descripción corta" },
               show_metrics: show_metrics,


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*
This fixes the displaying of images into the participatory processes,
This also fixes every editor commands onto files to avoid bugs in the future but still related to this issue, just on different features.

#### :pushpin: Related Issues
*Link your PR to an issue*
- [Notion card](https://www.notion.so/opensourcepolitics/Toulouse-bug-affichage-des-images-a9b20560941545378a113e9b4e9e37d4?pvs=4)

#### Tasks
- [x] Add specs
- [x] Refreshing the backports

