### PR TITLE
fix: phone numbers not found in exports

### DIFF
--- a/lib/extends/exporters/proposal_serializer.rb
+++ b/lib/extends/exporters/proposal_serializer.rb
@@ -71,24 +71,20 @@ module ProposalSerializerExtend
   def creator_phone_number
     return "" if proposal.creator_identity.blank?
 
-    return "" if proposal.creator_identity.try(:user_id).blank?
+    return "" if proposal.creator_identity.try(:id).blank?
 
-    phone_number(proposal.creator_identity.try(:user_id))
+    phone_number(proposal.creator_identity.try(:id))
   end
 
   # phone_number retrieve the phone number of an user stored from phone_authorization_handler
   # Param: user_id : Integer
   # Return string, empty or with the phone number
   def phone_number(user_id)
-    authorization = Decidim::Authorization.where(name: "phone_authorization_handler", decidim_user_id: user_id)
-    return "" if authorization.blank?
-
-    metadata = authorization.first.try(:metadata)
+    authorization = Decidim::Authorization.find_by(name: "phone_authorization_handler", decidim_user_id: user_id)
+    metadata = authorization.try(:metadata)
     return "" if metadata.blank?
 
-    # rubocop:disable Lint/SafeNavigationChain
-    authorization.first.try(:metadata)&.to_h["phone_number"].presence || ""
-    # rubocop:enable Lint/SafeNavigationChain
+    metadata.to_h["phone_number"].presence || ""
   end
 end
 


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

On proposals exports, the whole column "phone_number" is systematically empty. 


#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #118 
- [Notion card](https://www.notion.so/opensourcepolitics/Toulouse-Non-affichage-num-ro-tel-dans-exports-704979f01bac4022b54a289e1e3d0700?pvs=4)

#### Testing
*Describe the best way to test or validate your PR.*

Example:
* Log in as admin
* Activate Phone Authorization on proposal creation
* Create a proposal
* Export proposals
* See phone number in exports

If official proposal, should not export any phone number

#### Tasks
- [x] Add specs
- [x] Fix proposals serializer
