### PR TITLE
feat: Add newsletter to registration form

### DIFF
--- a/app/forms/decidim/registration_form.rb
+++ b/app/forms/decidim/registration_form.rb
@@ -24,6 +24,7 @@ module Decidim
     attribute :metropolis_residential_area, String
     attribute :metropolis_work_area, String
     attribute :gender, String
+    attribute :newsletter, Boolean
     attribute :tos_agreement, Boolean
     attribute :additional_tos, Boolean
     attribute :current_locale, String

--- a/app/views/decidim/devise/registrations/new.html.erb
+++ b/app/views/decidim/devise/registrations/new.html.erb
@@ -142,6 +142,19 @@
             </div>
           </div>
 
+          <div class="card" id="card__newsletter">
+            <div class="card__content">
+              <legend><%= t(".newsletter_title") %></legend>
+              <div class="row">
+                <div class="columns additional_tos_checkboxes">
+                  <div class="field">
+                    <%= f.check_box :newsletter, label: t(".newsletter"), checked: @form.newsletter %>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
           <div class="card" id="card__additional_tos">
             <div class="card__content">
               <legend><%= t(".additional_tos_title") %></legend>

--- a/spec/system/examples/registration_password_examples.rb
+++ b/spec/system/examples/registration_password_examples.rb
@@ -34,7 +34,7 @@ shared_examples "on/off registration passwords" do
       expect(page).to have_field("registration_user_nickname", with: "")
       expect(page).to have_field("registration_user_email", with: "")
       expect(page).to have_field("registration_user_password", with: "")
-      expect(page).not_to have_field("registration_user_newsletter", checked: false)
+      expect(page).to have_field("registration_user_newsletter", checked: false)
     end
 
     it "creates a new User" do
@@ -82,6 +82,7 @@ shared_examples "on/off registration passwords" do
 
           check :registration_user_tos_agreement
           check :registration_user_additional_tos
+          check :registration_user_newsletter
 
           check :registration_user_additional_tos
           find("*[type=submit]").click
@@ -105,7 +106,7 @@ shared_examples "on/off registration passwords" do
       expect(page).to have_field("registration_user_email", with: "")
       expect(page).to have_field("registration_user_password", with: "")
       expect(page).to have_field("registration_user_password_confirmation", with: "")
-      expect(page).not_to have_field("registration_user_newsletter", checked: false)
+      expect(page).to have_field("registration_user_newsletter", checked: false)
     end
 
     it "creates a new User" do
@@ -124,6 +125,7 @@ shared_examples "on/off registration passwords" do
         select "1992", from: :registration_user_year
 
         fill_in :registration_user_password_confirmation, with: "nonsense"
+        check :registration_user_newsletter
         check :registration_user_tos_agreement
         check :registration_user_additional_tos
         find("*[type=submit]").click
@@ -160,6 +162,7 @@ shared_examples "on/off registration passwords" do
           select "1992", from: :registration_user_year
 
           fill_in :registration_user_password_confirmation, with: "DfyvHn425mYAy2HL"
+          check :registration_user_newsletter
           check :registration_user_tos_agreement
           check :registration_user_additional_tos
 


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*
The purpose of this PR is to add again the newsletter's activation checkbox that was previously disabled.

#### :pushpin: Related Issues
*Link your PR to an issue*
- [Notion card](https://www.notion.so/opensourcepolitics/Toulouse-Dev-notifications-inscription-c1501a00f48c4140bfe1629ddce34e58?pvs=4)

#### Testing
*Describe the best way to test or validate your PR.*

Example:
* Register
* Check the newsletter checkbox
* Log as admin
* Send a newsletter
* Check if your new user has well received the newsletter

#### Tasks
- [x] Rework specs
- [x] Add the newsletter checkbox

