### PR TITLE
fix: Add again email_on_notification

### DIFF
--- a/app/commands/decidim/create_registration.rb
+++ b/app/commands/decidim/create_registration.rb
@@ -46,7 +46,7 @@ module Decidim
         organization: form.current_organization,
         tos_agreement: form.tos_agreement,
         newsletter_notifications_at: form.newsletter_at,
-        email_on_notification: false,
+        email_on_notification: true,
         accepted_tos_version: form.current_organization.tos_version,
         locale: form.current_locale,
         registration_metadata: registration_metadata

--- a/spec/commands/decidim/create_registration_spec.rb
+++ b/spec/commands/decidim/create_registration_spec.rb
@@ -151,7 +151,7 @@ module Decidim
               password: form.password,
               password_confirmation: form.password_confirmation,
               tos_agreement: form.tos_agreement,
-              email_on_notification: false,
+              email_on_notification: true,
               organization: organization,
               accepted_tos_version: organization.tos_version,
               locale: form.current_locale,


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

`email_on_notification` is disabled by default and user does not receive welcome email. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to [Notion](https://www.notion.so/opensourcepolitics/Toulouse-Dev-notifications-inscription-c1501a00f48c4140bfe1629ddce34e58?pvs=4)

#### Testing
*Describe the best way to test or validate your PR.*
* Create a new account
* Go to letter opener (http://localhost:3000/letter_opener)
* Enter confirmation code 
* See received welcome message
