### PR TITLE
fix: Rack attack can't be completely disabled

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -6,4 +6,13 @@ require "decidim_app/rack_attack/fail2ban"
 
 # Enabled by default in production
 # Can be deactivated with 'ENABLE_RACK_ATTACK=0'
-DecidimApp::RackAttack.apply_configuration if DecidimApp::RackAttack.rack_enabled?
+DecidimApp::RackAttack.deactivate_decidim_throttling!
+
+if DecidimApp::RackAttack.rack_enabled?
+  DecidimApp::RackAttack.enable_rack_attack!
+  DecidimApp::RackAttack.apply_configuration
+else
+  DecidimApp::RackAttack.disable_rack_attack!
+end
+
+DecidimApp::RackAttack.info!

--- a/lib/decidim_app/rack_attack.rb
+++ b/lib/decidim_app/rack_attack.rb
@@ -4,21 +4,39 @@ module DecidimApp
   module RackAttack
     def self.rack_enabled?
       setting = Rails.application.secrets.dig(:decidim, :rack_attack, :enabled)
-      return setting == "1" if setting.present?
+      return setting.to_s == "1" if setting.present?
 
       Rails.env.production?
     end
 
-    def self.apply_configuration
-      Rack::Attack.enabled = true
+    def self.info!
+      Rails.logger.info("Rack::Attack is enabled: #{Rack::Attack.enabled}")
+      Rails.logger.info("Rack::Attack Fail2ban is enabled: #{DecidimApp::RackAttack::Fail2ban.enabled?}")
+      Rack::Attack.throttles.keys.each do |throttle|
+        Rails.logger.info("Rack::Attack throttling registered: #{throttle}")
+      end
+    end
 
+    def self.enable_rack_attack!
+      Rails.logger.info("Rack::Attack is now enabled")
+      Rack::Attack.enabled = true
+    end
+
+    def self.disable_rack_attack!
+      Rails.logger.info("Rack::Attack is now disabled")
+      Rack::Attack.enabled = false
+    end
+
+    def self.deactivate_decidim_throttling!
       # Remove the original throttle from decidim-core
-      # see https://github.com/decidim/decidim/blob/release/0.26-stable/decidim-core/config/initializers/rack_attack.rb#L19
+      # see https://github.com/decidim/decidim/blob/release/0.27-stable/decidim-core/config/initializers/rack_attack.rb#L19
       DecidimApp::RackAttack::Throttling.deactivate_decidim_throttling! do
         Rails.logger.info("Deactivating 'requests by ip' from Decidim Core")
         Rack::Attack.throttles.delete("requests by ip")
       end
+    end
 
+    def self.apply_configuration
       Rack::Attack.throttled_response_retry_after_header = true
 
       Rack::Attack.throttled_responder = lambda do |request|

--- a/spec/system/confirmation_spec.rb
+++ b/spec/system/confirmation_spec.rb
@@ -76,7 +76,7 @@ describe "Registration", type: :system do
 
     before do
       allow(Rails).to receive(:cache).and_return(memory_store)
-      DecidimApp::RackAttack.apply_configuration
+      DecidimApp::RackAttack.enable_rack_attack!
       Rack::Attack.reset!
 
       visit decidim_friendly_signup.confirmation_codes_path(confirmation_token: confirmation_token)
@@ -88,7 +88,7 @@ describe "Registration", type: :system do
     end
 
     after do
-      Rack::Attack.enabled = false
+      DecidimApp::RackAttack.disable_rack_attack!
     end
 
     it "throttles after 5 attempts per minute" do


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

Add configuration to disable completely rack attack using env var `ENABLE_RACK_ATTACK=0`

Now initializer logs the current Rack Attack configuration on startup

#### Related to 
- Backport from [decidim-app#449](https://github.com/OpenSourcePolitics/decidim-app/pull/449)

#### Tasks
- [x] Add specs
