### PR TITLE
feat: backport related processes sort

### DIFF
--- a/app/controllers/decidim/assemblies/assemblies_controller.rb
+++ b/app/controllers/decidim/assemblies/assemblies_controller.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Assemblies
+    # A controller that holds the logic to show Assemblies in a public layout.
+    class AssembliesController < Decidim::Assemblies::ApplicationController
+      include ParticipatorySpaceContext
+      participatory_space_layout only: :show
+      include FilterResource
+
+      helper_method :parent_assemblies, :promoted_assemblies, :stats, :assembly_participatory_processes, :current_assemblies_settings
+
+      def index
+        enforce_permission_to :list, :assembly
+
+        respond_to do |format|
+          format.html do
+            raise ActionController::RoutingError, "Not Found" if published_assemblies.none?
+
+            render "index"
+          end
+
+          format.js do
+            raise ActionController::RoutingError, "Not Found" if published_assemblies.none?
+
+            render "index"
+          end
+
+          format.json do
+            render json: published_assemblies.query.includes(:children).where(parent: nil).collect { |assembly|
+              {
+                name: assembly.title[I18n.locale.to_s],
+                children: assembly.children.collect do |child|
+                  {
+                    name: child.title[I18n.locale.to_s],
+                    children: child.children.collect { |child_of_child| { name: child_of_child.title[I18n.locale.to_s] } }
+                  }
+                end
+              }
+            }
+          end
+        end
+      end
+
+      def show
+        enforce_permission_to :read, :assembly, assembly: current_participatory_space
+      end
+
+      private
+
+      def search_collection
+        Assembly.where(organization: current_organization).published.visible_for(current_user)
+      end
+
+      def default_filter_params
+        {
+          with_scope: nil,
+          with_area: nil,
+          type_id_eq: nil
+        }
+      end
+
+      def current_participatory_space
+        return unless params[:slug]
+
+        @current_participatory_space ||= OrganizationAssemblies.new(current_organization).query.where(slug: params[:slug]).or(
+          OrganizationAssemblies.new(current_organization).query.where(id: params[:slug])
+        ).first!
+      end
+
+      def published_assemblies
+        @published_assemblies ||= OrganizationPublishedAssemblies.new(current_organization, current_user)
+      end
+
+      def promoted_assemblies
+        @promoted_assemblies ||= published_assemblies | PromotedAssemblies.new
+      end
+
+      def parent_assemblies
+        search.result.parent_assemblies.order(weight: :asc, promoted: :desc)
+      end
+
+      def stats
+        @stats ||= AssemblyStatsPresenter.new(assembly: current_participatory_space)
+      end
+
+      def assembly_participatory_processes
+        related_pps = @current_participatory_space.linked_participatory_space_resources(:participatory_processes, "included_participatory_processes")
+                                                  .order(end_date: :desc, start_date: :asc)
+
+        @assembly_participatory_processes ||= sort_related_pp(related_pps)
+      end
+
+      # Sort PPs by active state
+      # Param : participatory_processes : Decidim::ParticipatoryProcess::ActiveRecord_Relation
+      # Returns : Array || Decidim::ParticipatoryProcess::ActiveRecord_Relation
+      def sort_related_pp(participatory_processes)
+        active_pps, closed_pps = participatory_processes&.partition(&:active?)
+        (active_pps + closed_pps).uniq.presence || participatory_processes
+      end
+
+      def current_assemblies_settings
+        @current_assemblies_settings ||= Decidim::AssembliesSetting.find_or_create_by(decidim_organization_id: current_organization.id)
+      end
+    end
+  end
+end

--- a/spec/controllers/assemblies_controller_spec.rb
+++ b/spec/controllers/assemblies_controller_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Assemblies
+    describe AssembliesController, type: :controller do
+      routes { Decidim::Assemblies::Engine.routes }
+
+      let(:organization) { create(:organization) }
+
+      let!(:unpublished_assembly) do
+        create(
+          :assembly,
+          :unpublished,
+          organization: organization
+        )
+      end
+
+      let!(:published) do
+        create(
+          :assembly,
+          :published,
+          organization: organization
+        )
+      end
+
+      let!(:promoted) do
+        create(
+          :assembly,
+          :published,
+          :promoted,
+          organization: organization
+        )
+      end
+
+      before do
+        request.env["decidim.current_organization"] = organization
+      end
+
+      describe "published_assemblies" do
+        context "when there are no published assemblies" do
+          before do
+            published.unpublish!
+            promoted.unpublish!
+          end
+
+          it "redirects to 404" do
+            expect { get :index }.to raise_error(ActionController::RoutingError)
+          end
+        end
+      end
+
+      describe "GET assemblies in json format" do
+        let!(:first_level) { create(:assembly, :published, :with_parent, parent: published, organization: organization) }
+        let!(:second_level) { create(:assembly, :published, :with_parent, parent: first_level, organization: organization) }
+        let!(:third_level) { create(:assembly, :published, :with_parent, parent: second_level, organization: organization) }
+
+        let(:parsed_response) { JSON.parse(response.body, symbolize_names: true) }
+
+        it "includes only published assemblies with their children (two levels)" do
+          get :index, format: :json
+          expect(parsed_response).to match_array(
+            [
+              {
+                name: translated(promoted.title),
+                children: []
+              },
+              {
+                name: translated(published.title),
+                children: [
+                  {
+                    name: translated(first_level.title),
+                    children: [{ name: translated(second_level.title) }]
+                  }
+                ]
+              }
+            ]
+          )
+        end
+      end
+
+      describe "promoted_assemblies" do
+        it "includes only promoted" do
+          expect(controller.helpers.promoted_assemblies).to contain_exactly(promoted)
+        end
+      end
+
+      describe "parent_assemblies" do
+        let!(:child_assembly) { create(:assembly, parent: published, organization: organization) }
+
+        it "includes only parent assemblies, with promoted listed first" do
+          expect(controller.helpers.parent_assemblies.first).to eq(promoted)
+          expect(controller.helpers.parent_assemblies.second).to eq(published)
+        end
+      end
+
+      describe "GET show" do
+        context "when the assembly is unpublished" do
+          it "redirects to sign in path" do
+            get :show, params: { slug: unpublished_assembly.slug }
+
+            expect(response).to redirect_to("/users/sign_in")
+          end
+
+          context "with signed in user" do
+            let!(:user) { create(:user, :confirmed, organization: organization) }
+
+            before do
+              sign_in user, scope: :user
+            end
+
+            it "redirects to root path" do
+              get :show, params: { slug: unpublished_assembly.slug }
+
+              expect(response).to redirect_to("/")
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

As a user, I expect related processes to be ordered by start date in assemblies show. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to backport of : #50 
- [Notion card](https://www.notion.so/opensourcepolitics/Toulouse-Mont-e-de-version-0-27-3cb7e71e74c246f4a65bec7f980208ce?pvs=4)
- [Notion card](https://www.notion.so/opensourcepolitics/Toulouse-Order-of-related-processes-in-assemblies-show-61390f84fe734d65b76fbe4638583f73?pvs=4)

#### Tasks
- [x] Add specs
- [x] Keep open-data link deactivated
