### PR TITLE
feature: Sort processes linked to assemblies

### DIFF
--- a/app/controllers/decidim/assemblies/assemblies_controller.rb
+++ b/app/controllers/decidim/assemblies/assemblies_controller.rb
@@ -88,7 +88,7 @@ module Decidim
         assembly_participatory_processes = @current_participatory_space.linked_participatory_space_resources(:participatory_processes, "included_participatory_processes")
 
         sorted_by_date = {
-          active: assembly_participatory_processes.active_spaces.order(start_date: :desc),
+          active: assembly_participatory_processes.active_spaces.order(end_date: :desc),
           future: assembly_participatory_processes.future_spaces.order(start_date: :asc),
           past: assembly_participatory_processes.past_spaces.order(end_date: :desc)
         }

--- a/app/controllers/decidim/assemblies/assemblies_controller.rb
+++ b/app/controllers/decidim/assemblies/assemblies_controller.rb
@@ -88,9 +88,9 @@ module Decidim
         assembly_participatory_processes = @current_participatory_space.linked_participatory_space_resources(:participatory_processes, "included_participatory_processes")
 
         sorted_by_date = {
-          active: assembly_participatory_processes.active_spaces.order(end_date: :asc),
-          future: assembly_participatory_processes.future_spaces.order(start_date: :asc),
-          past: assembly_participatory_processes.past_spaces.order(end_date: :desc)
+          active: assembly_participatory_processes.active_spaces.sort_by(&:end_date).reverse,
+          future: assembly_participatory_processes.future_spaces.sort_by(&:start_date),
+          past: assembly_participatory_processes.past_spaces.sort_by(&:end_date).reverse
         }
 
         @assembly_participatory_processes ||= sorted_by_date

--- a/app/controllers/decidim/assemblies/assemblies_controller.rb
+++ b/app/controllers/decidim/assemblies/assemblies_controller.rb
@@ -85,10 +85,15 @@ module Decidim
       end
 
       def assembly_participatory_processes
-        related_pps = @current_participatory_space.linked_participatory_space_resources(:participatory_processes, "included_participatory_processes")
-                                                  .order(end_date: :desc, start_date: :asc)
+        assembly_participatory_processes = @current_participatory_space.linked_participatory_space_resources(:participatory_processes, "included_participatory_processes")
 
-        @assembly_participatory_processes ||= sort_related_pp(related_pps)
+        sorted_by_date = {
+          active: assembly_participatory_processes.active_spaces.order(start_date: :desc),
+          future: assembly_participatory_processes.future_spaces.order(start_date: :asc),
+          past: assembly_participatory_processes.past_spaces.order(end_date: :desc)
+        }
+
+        @assembly_participatory_processes ||= sorted_by_date
       end
 
       # Sort PPs by active state

--- a/app/controllers/decidim/assemblies/assemblies_controller.rb
+++ b/app/controllers/decidim/assemblies/assemblies_controller.rb
@@ -88,7 +88,7 @@ module Decidim
         assembly_participatory_processes = @current_participatory_space.linked_participatory_space_resources(:participatory_processes, "included_participatory_processes")
 
         sorted_by_date = {
-          active: assembly_participatory_processes.active_spaces.order(end_date: :desc),
+          active: assembly_participatory_processes.active_spaces.order(end_date: :asc),
           future: assembly_participatory_processes.future_spaces.order(start_date: :asc),
           past: assembly_participatory_processes.past_spaces.order(end_date: :desc)
         }

--- a/app/controllers/decidim/assemblies/assemblies_controller.rb
+++ b/app/controllers/decidim/assemblies/assemblies_controller.rb
@@ -88,7 +88,7 @@ module Decidim
         assembly_participatory_processes = @current_participatory_space.linked_participatory_space_resources(:participatory_processes, "included_participatory_processes")
 
         sorted_by_date = {
-          active: assembly_participatory_processes.active_spaces.sort_by(&:end_date).reverse,
+          active: assembly_participatory_processes.active_spaces.sort_by(&:end_date),
           future: assembly_participatory_processes.future_spaces.sort_by(&:start_date),
           past: assembly_participatory_processes.past_spaces.sort_by(&:end_date).reverse
         }

--- a/app/helpers/decidim/assemblies/assemblies_helper.rb
+++ b/app/helpers/decidim/assemblies/assemblies_helper.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Assemblies
+    # Helpers related to the Assemblies layout.
+    module AssembliesHelper
+      include Decidim::ResourceHelper
+      include Decidim::AttachmentsHelper
+      include Decidim::IconHelper
+      include Decidim::WidgetUrlsHelper
+      include Decidim::SanitizeHelper
+      include Decidim::ResourceReferenceHelper
+      include Decidim::FiltersHelper
+      include FilterAssembliesHelper
+
+      # Public: Returns the characteristics of an assembly in a readable format like
+      # "title: close, no public, no transparent and is restricted to the members of the assembly"
+      def participatory_processes_for_assembly(assembly_participatory_processes)
+        return if assembly_participatory_processes.values.all?(&:empty?)
+
+        html = ""
+        html += %( <div class="section"> ).html_safe
+        html += %( <h4 class="section-heading">#{t("assemblies.show.related_participatory_processes", scope: "decidim")} <span class="margin-right-1"></span> ).html_safe
+
+        assembly_participatory_processes.each do |type, processes|
+          next if processes.empty?
+
+          html += %( <a href="##{type}_assembly_participatory_processes" class="order-by__tab text-small">
+            #{t("assemblies.show.#{type}_assembly_participatory_processes_mini", scope: "decidim")}
+            (#{processes.count})</a> ).html_safe
+        end
+
+        html += %( </h4> ).html_safe
+        html += %( <div class="column"> ).html_safe
+
+        assembly_participatory_processes.each do |type, processes|
+          next if processes.empty?
+
+          html += %( <h5 id="#{type}_assembly_participatory_processes" class="section-heading">
+            #{t("assemblies.show.#{type}_assembly_participatory_processes", scope: "decidim")}</h5> ).html_safe
+          html += %( <div class="row small-up-1 medium-up-2 card-grid"> ).html_safe
+          processes.each do |process|
+            html += render partial: "decidim/participatory_processes/participatory_process", locals: { participatory_process: process }
+          end
+          html += %( </div> ).html_safe
+        end
+
+        html += %( </div> ).html_safe
+        html += %( </div> ).html_safe
+
+        html.html_safe
+      end
+
+      def assembly_features(assembly)
+        html = "".html_safe
+        html += "<strong>#{translated_attribute(assembly.title)}: </strong>".html_safe
+        html += t("assemblies.show.private_space", scope: "decidim").to_s.html_safe
+        html += ", #{t("assemblies.show.is_transparent.#{assembly.is_transparent}", scope: "decidim")}".html_safe if assembly.is_transparent?
+        html += " #{decidim_sanitize_editor translated_attribute(assembly.special_features)}".html_safe
+        html.html_safe
+      end
+
+      def social_handler_links(assembly)
+        html = "".html_safe
+        if Decidim::Assembly::SOCIAL_HANDLERS.any? { |h| assembly.try("#{h}_handler").present? }
+          html += "<div class='definition-data__item social_networks'>".html_safe
+          html += "<span class='definition-data__title'>#{t("assemblies.show.social_networks", scope: "decidim")}</span>".html_safe
+          Decidim::Assembly::SOCIAL_HANDLERS.each do |handler|
+            handler_name = "#{handler}_handler"
+            next if assembly.send(handler_name).blank?
+
+            html += link_to handler.capitalize, "https://#{handler}.com/#{assembly.send(handler_name)}",
+                            target: "_blank",
+                            class: "",
+                            title: t("assemblies.show.social_networks_title", scope: "decidim") << " " << handler.capitalize.to_s, rel: "noopener"
+          end
+          html += "</div>".html_safe
+        end
+
+        html.html_safe
+      end
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,6 +27,12 @@ en:
             This amendment for %{amendable_type} %{proposal_link}
             is in evaluation state.
     anonymous_user: Anonymous user
+    assemblies:
+      show:
+        private_space: This is a private assembly
+        related_participatory_processes: Related participatory processes
+        social_networks: Social Networks
+        social_networks_title: Visit assembly on
     authorization_handlers:
       osp_authorization_handler:
         explanation: Verify your identity by entering a unique number

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -29,6 +29,12 @@ fr:
             Cet amendement pour le %{amendable_type} %{proposal_link}
             est en cours d’évaluation.
     anonymous_user: Utilisateur anonyme
+    assemblies:
+      show:
+        private_space: Ceci est une assemblée privée
+        related_participatory_processes: Concertations associées
+        social_networks: Réseaux sociaux
+        social_networks_title: Visiter l'assemblée sur
     authorization_handlers:
       osp_authorization_handler:
         explanation: Vérifier votre identité en saisissant un numéro unique

--- a/spec/controllers/assemblies_controller_spec.rb
+++ b/spec/controllers/assemblies_controller_spec.rb
@@ -145,7 +145,7 @@ module Decidim
 
         it "includes only participatory processes related to the assembly, actives one by end_date then upcoming ones by start_date then past ones by end_date reversed" do
           sorted_participatory_processes = {
-            active: participatory_processes.select(&:active?).sort_by(&:end_date).reverse,
+            active: participatory_processes.select(&:active?).sort_by(&:end_date),
             future: participatory_processes.select(&:upcoming?).sort_by(&:start_date),
             past: participatory_processes.select(&:past?).sort_by(&:end_date).reverse
           }

--- a/spec/controllers/assemblies_controller_spec.rb
+++ b/spec/controllers/assemblies_controller_spec.rb
@@ -145,7 +145,7 @@ module Decidim
 
         it "includes only participatory processes related to the assembly, actives one by end_date then upcoming ones by start_date then past ones by end_date reversed" do
           sorted_participatory_processes = {
-            active: participatory_processes.select(&:active?).sort_by(&:start_date).reverse,
+            active: participatory_processes.select(&:active?).sort_by(&:end_date).reverse,
             future: participatory_processes.select(&:upcoming?).sort_by(&:start_date),
             past: participatory_processes.select(&:past?).sort_by(&:end_date).reverse
           }

--- a/spec/controllers/assemblies_controller_spec.rb
+++ b/spec/controllers/assemblies_controller_spec.rb
@@ -145,7 +145,7 @@ module Decidim
 
         it "includes only participatory processes related to the assembly, actives one by end_date then upcoming ones by start_date then past ones by end_date reversed" do
           sorted_participatory_processes = {
-            active: participatory_processes.select(&:active?).sort_by(&:end_date),
+            active: participatory_processes.select(&:active?).sort_by(&:end_date).reverse,
             future: participatory_processes.select(&:upcoming?).sort_by(&:start_date),
             past: participatory_processes.select(&:past?).sort_by(&:end_date).reverse
           }

--- a/spec/controllers/assemblies_controller_spec.rb
+++ b/spec/controllers/assemblies_controller_spec.rb
@@ -95,6 +95,77 @@ module Decidim
         end
       end
 
+      describe "assembly_participatory_processes" do
+        let!(:organization) { create(:organization) }
+        let!(:past_processes) do
+          5.times.map do |i|
+            create(
+              :participatory_process,
+              :published,
+              organization: organization,
+              start_date: Time.zone.now - (i + 10).days,
+              end_date: Time.zone.now - (i + 5).days
+            )
+          end
+        end
+
+        let!(:active_processes) do
+          5.times.map do |i|
+            create(
+              :participatory_process,
+              :published,
+              organization: organization,
+              start_date: Time.zone.now - (i + 5).days,
+              end_date: Time.zone.now + (i + 5).days
+            )
+          end
+        end
+
+        let!(:upcoming_processes) do
+          5.times.map do |i|
+            create(
+              :participatory_process,
+              :published,
+              organization: organization,
+              start_date: Time.zone.now + (i + 5).days,
+              end_date: Time.zone.now + (i + 10).days
+            )
+          end
+        end
+
+        let(:participatory_processes) do
+          past_processes + active_processes + upcoming_processes
+        end
+
+        before do
+          published.link_participatory_space_resources(participatory_processes, "included_participatory_processes")
+          current_participatory_space = published
+          controller.instance_variable_set(:@current_participatory_space, current_participatory_space)
+        end
+
+        it "includes only participatory processes related to the assembly, actives one by end_date then upcoming ones by start_date then past ones by end_date reversed" do
+          sorted_participatory_processes = {
+            active: participatory_processes.select(&:active?).sort_by(&:start_date).reverse,
+            future: participatory_processes.select(&:upcoming?).sort_by(&:start_date),
+            past: participatory_processes.select(&:past?).sort_by(&:end_date).reverse
+          }
+
+          expect(controller.helpers.assembly_participatory_processes).to eq(sorted_participatory_processes)
+        end
+
+        it "includes only active participatory processes" do
+          expect(controller.helpers.assembly_participatory_processes[:active].all?(&:active?)).to be true
+        end
+
+        it "includes only upcoming participatory processes" do
+          expect(controller.helpers.assembly_participatory_processes[:future].all?(&:upcoming?)).to be true
+        end
+
+        it "includes only past participatory processes" do
+          expect(controller.helpers.assembly_participatory_processes[:past].all?(&:past?)).to be true
+        end
+      end
+
       describe "GET show" do
         context "when the assembly is unpublished" do
           it "redirects to sign in path" do


### PR DESCRIPTION
#### :tophat: Description

This pull request backport a change that was made on 0.26 about sorting processes that are linked to assemblies onto the assemblies page.

#### :pushpin: Related Issues
*Link your PR to an issue*
- [Notion card](https://www.notion.so/opensourcepolitics/Toulouse-Mont-e-de-version-0-27-3cb7e71e74c246f4a65bec7f980208ce?pvs=4)

#### Testing
*Describe the best way to test or validate your PR.*

Example:
* Log in as admin
* Access Backoffice
* Create few processes , past active and future.
* Go to assemblies and select one
* Link new processes to the assemblies
* Access assemblies page in the front office
* Check that everything has been well sorted

#### Tasks
- [x] Add specs
- [x] Override assemblies helper
- [x] Override method in controller

## 🚨 It disables completely the weight ordering feature of Decidim we must be aware of that
