### PR TITLE
feat: Allow to configure notifications_sending_frequency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem "decidim-cache_cleaner"
 gem "decidim-decidim_awesome"
 gem "decidim-extended_socio_demographic_authorization_handler", git: "https://github.com/OpenSourcePolitics/decidim-module-extended_socio_demographic_authorization_handler.git",
                                                                 branch: DECIDIM_BRANCH
-gem "decidim-extra_user_fields", git: "https://github.com/PopulateTools/decidim-module-extra_user_fields.git", branch: "release/0.27-stable"
+gem "decidim-extra_user_fields", git: "https://github.com/OpenSourcePolitics/decidim-module-extra_user_fields.git", branch: "feat/notifications_sending_frequency"
 gem "decidim-friendly_signup", git: "https://github.com/OpenSourcePolitics/decidim-module-friendly_signup.git"
 gem "decidim-gallery", git: "https://github.com/OpenSourcePolitics/decidim-module-gallery.git", branch: "fix/nokogiri_deps"
 gem "decidim-homepage_interactive_map", git: "https://github.com/OpenSourcePolitics/decidim-module-homepage_interactive_map.git", branch: DECIDIM_BRANCH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,16 @@ GIT
       decidim-core (~> 0.27)
 
 GIT
+  remote: https://github.com/OpenSourcePolitics/decidim-module-extra_user_fields.git
+  revision: 9517905551332c4145796bc21ef5e035f99176b4
+  branch: feat/notifications_sending_frequency
+  specs:
+    decidim-extra_user_fields (0.27.2)
+      country_select (~> 4.0)
+      decidim-core (>= 0.27.0, < 0.28)
+      deface (~> 1.5)
+
+GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-friendly_signup.git
   revision: 1a054faf964cc6ed07f1bec47cb92f0083a5bcb4
   specs:
@@ -73,16 +83,6 @@ GIT
     omniauth-publik (0.1.1)
       omniauth (~> 2.0)
       omniauth-oauth2 (>= 1.7.2, < 2.0)
-
-GIT
-  remote: https://github.com/PopulateTools/decidim-module-extra_user_fields.git
-  revision: ef262d6619ef254de1379278f56c4c6af789e54c
-  branch: release/0.27-stable
-  specs:
-    decidim-extra_user_fields (0.27.2)
-      country_select (~> 4.0)
-      decidim-core (>= 0.27.0, < 0.28)
-      deface (~> 1.5)
 
 GIT
   remote: https://github.com/alecslupu-pfa/decidim-module-survey_multiple_answers

--- a/config/initializers/friendly_signup.rb
+++ b/config/initializers/friendly_signup.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+
+return unless defined?(Decidim::FriendlySignup)
+
 Decidim::FriendlySignup.configure do |config|
   # Override password views or leave the originals (default is true):
   config.override_passwords = ENV.fetch("FRIENDLY_SIGNUP_OVERRIDE_PASSWORDS", "1") == "1"

--- a/config/initializers/friendly_signup.rb
+++ b/config/initializers/friendly_signup.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-
 return unless defined?(Decidim::FriendlySignup)
 
 Decidim::FriendlySignup.configure do |config|

--- a/spec/commands/decidim/create_registration_spec.rb
+++ b/spec/commands/decidim/create_registration_spec.rb
@@ -78,6 +78,10 @@ module Decidim
       end
 
       describe "when the form is valid" do
+        before do
+          Decidim::ExtraUserFields.notifications_sending_frequency = "none"
+        end
+
         it "broadcasts ok" do
           expect { command.call }.to broadcast(:ok)
         end

--- a/spec/commands/decidim/create_registration_spec.rb
+++ b/spec/commands/decidim/create_registration_spec.rb
@@ -3,7 +3,6 @@
 require "spec_helper"
 
 module Decidim
-  module Comments
     describe CreateRegistration do
       describe "call" do
         let(:organization) { create(:organization) }
@@ -16,6 +15,7 @@ module Decidim
         let(:tos_agreement) { "1" }
         let(:newsletter) { "1" }
         let(:current_locale) { "fr" }
+        let(:notifications_sending_frequency) { "none" }
 
         let(:form_params) do
           {
@@ -95,6 +95,7 @@ module Decidim
               accepted_tos_version: organization.tos_version,
               locale: form.current_locale,
               password_updated_at: an_instance_of(ActiveSupport::TimeWithZone),
+              notifications_sending_frequency: "none",
               extended_data: {
                 country: nil,
                 date_of_birth: nil,
@@ -121,5 +122,4 @@ module Decidim
         end
       end
     end
-  end
 end

--- a/spec/commands/decidim/create_registration_spec.rb
+++ b/spec/commands/decidim/create_registration_spec.rb
@@ -3,123 +3,123 @@
 require "spec_helper"
 
 module Decidim
-    describe CreateRegistration do
-      describe "call" do
-        let(:organization) { create(:organization) }
+  describe CreateRegistration do
+    describe "call" do
+      let(:organization) { create(:organization) }
 
-        let(:name) { "Username" }
-        let(:nickname) { "nickname" }
-        let(:email) { "user@example.org" }
-        let(:password) { "Y1fERVzL2F" }
-        let(:password_confirmation) { password }
-        let(:tos_agreement) { "1" }
-        let(:newsletter) { "1" }
-        let(:current_locale) { "fr" }
-        let(:notifications_sending_frequency) { "none" }
+      let(:name) { "Username" }
+      let(:nickname) { "nickname" }
+      let(:email) { "user@example.org" }
+      let(:password) { "Y1fERVzL2F" }
+      let(:password_confirmation) { password }
+      let(:tos_agreement) { "1" }
+      let(:newsletter) { "1" }
+      let(:current_locale) { "fr" }
+      let(:notifications_sending_frequency) { "none" }
 
-        let(:form_params) do
-          {
-            "user" => {
-              "name" => name,
-              "nickname" => nickname,
-              "email" => email,
-              "password" => password,
-              "password_confirmation" => password_confirmation,
-              "tos_agreement" => tos_agreement,
-              "newsletter_at" => newsletter
-            }
+      let(:form_params) do
+        {
+          "user" => {
+            "name" => name,
+            "nickname" => nickname,
+            "email" => email,
+            "password" => password,
+            "password_confirmation" => password_confirmation,
+            "tos_agreement" => tos_agreement,
+            "newsletter_at" => newsletter
           }
-        end
-        let(:form) do
-          RegistrationForm.from_params(
-            form_params,
-            current_locale: current_locale
-          ).with_context(
-            current_organization: organization
-          )
-        end
-        let(:command) { described_class.new(form) }
+        }
+      end
+      let(:form) do
+        RegistrationForm.from_params(
+          form_params,
+          current_locale: current_locale
+        ).with_context(
+          current_organization: organization
+        )
+      end
+      let(:command) { described_class.new(form) }
 
-        describe "when the form is not valid" do
+      describe "when the form is not valid" do
+        before do
+          allow(form).to receive(:invalid?).and_return(true)
+        end
+
+        it "broadcasts invalid" do
+          expect { command.call }.to broadcast(:invalid)
+        end
+
+        it "doesn't create a user" do
+          expect do
+            command.call
+          end.not_to change(User, :count)
+        end
+
+        context "when the user was already invited" do
+          let(:user) { build(:user, email: email, organization: organization) }
+
           before do
-            allow(form).to receive(:invalid?).and_return(true)
+            user.invite!
+            clear_enqueued_jobs
           end
 
-          it "broadcasts invalid" do
-            expect { command.call }.to broadcast(:invalid)
-          end
-
-          it "doesn't create a user" do
+          # rubocop:disable RSpec/ChangeByZero
+          it "receives the invitation email again" do
             expect do
               command.call
-            end.not_to change(User, :count)
+              user.reload
+            end.to change(User, :count).by(0)
+               .and broadcast(:invalid)
+               .and change(user.reload, :invitation_token)
+            expect(ActionMailer::MailDeliveryJob).to have_been_enqueued.on_queue("mailers")
           end
+          # rubocop:enable RSpec/ChangeByZero
+        end
+      end
 
-          context "when the user was already invited" do
-            let(:user) { build(:user, email: email, organization: organization) }
-
-            before do
-              user.invite!
-              clear_enqueued_jobs
-            end
-
-            # rubocop:disable RSpec/ChangeByZero
-            it "receives the invitation email again" do
-              expect do
-                command.call
-                user.reload
-              end.to change(User, :count).by(0)
-                 .and broadcast(:invalid)
-                 .and change(user.reload, :invitation_token)
-              expect(ActionMailer::MailDeliveryJob).to have_been_enqueued.on_queue("mailers")
-            end
-            # rubocop:enable RSpec/ChangeByZero
-          end
+      describe "when the form is valid" do
+        it "broadcasts ok" do
+          expect { command.call }.to broadcast(:ok)
         end
 
-        describe "when the form is valid" do
-          it "broadcasts ok" do
-            expect { command.call }.to broadcast(:ok)
-          end
+        it "creates a new user" do
+          expect(User).to receive(:create!).with(
+            name: form.name,
+            nickname: form.nickname,
+            email: form.email,
+            password: form.password,
+            password_confirmation: form.password_confirmation,
+            tos_agreement: form.tos_agreement,
+            newsletter_notifications_at: form.newsletter_at,
+            organization: organization,
+            accepted_tos_version: organization.tos_version,
+            locale: form.current_locale,
+            password_updated_at: an_instance_of(ActiveSupport::TimeWithZone),
+            notifications_sending_frequency: "none",
+            extended_data: {
+              country: nil,
+              date_of_birth: nil,
+              gender: nil,
+              location: nil,
+              phone_number: nil,
+              postal_code: nil
+            }
+          ).and_call_original
 
-          it "creates a new user" do
-            expect(User).to receive(:create!).with(
-              name: form.name,
-              nickname: form.nickname,
-              email: form.email,
-              password: form.password,
-              password_confirmation: form.password_confirmation,
-              tos_agreement: form.tos_agreement,
-              newsletter_notifications_at: form.newsletter_at,
-              organization: organization,
-              accepted_tos_version: organization.tos_version,
-              locale: form.current_locale,
-              password_updated_at: an_instance_of(ActiveSupport::TimeWithZone),
-              notifications_sending_frequency: "none",
-              extended_data: {
-                country: nil,
-                date_of_birth: nil,
-                gender: nil,
-                location: nil,
-                phone_number: nil,
-                postal_code: nil
-              }
-            ).and_call_original
+          expect { command.call }.to change(User, :count).by(1)
+        end
 
-            expect { command.call }.to change(User, :count).by(1)
-          end
+        describe "when user keeps the newsletter unchecked" do
+          let(:newsletter) { "0" }
 
-          describe "when user keeps the newsletter unchecked" do
-            let(:newsletter) { "0" }
-
-            it "creates a user with no newsletter notifications" do
-              expect do
-                command.call
-                expect(User.last.newsletter_notifications_at).to be_nil
-              end.to change(User, :count).by(1)
-            end
+          it "creates a user with no newsletter notifications" do
+            expect do
+              command.call
+              expect(User.last.newsletter_notifications_at).to be_nil
+            end.to change(User, :count).by(1)
           end
         end
       end
     end
+  end
 end


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

Allow to configure `notifications_sending_frequency` with ENV var `NOTIFICATIONS_SENDING_FREQUENCY` 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to https://github.com/OpenSourcePolitics/decidim-module-extra_user_fields/pull/1
- [Notion card](https://www.notion.so/opensourcepolitics/Toulouse-0-27-Param-trer-le-digest-notification-sur-Jamais-f46c952bab0b4c8886e3d1b5e6b6dbff?pvs=4)

#### Testing
*Describe the best way to test or validate your PR.*

Example:
* Run server with env var : `NOTIFICATIONS_SENDING_FREQUENCY=none bundle exec rails s`
* Create registration
* Login and check "My account"

#### Tasks
- [ ] Add specs
- [ ] Add note about overrides in OVERLOADS.md
- [ ] In case of new dependencies or version bump, update related documentation

### :camera: Screenshots
*Please add screenshots of the changes you're proposing if related to the UI*
