### PR TITLE
fix: Set Notification Frequency migration for Decidim users

### DIFF
--- a/db/migrate/20240419095228_modify_notification_frequency_for_decidim_users.rb
+++ b/db/migrate/20240419095228_modify_notification_frequency_for_decidim_users.rb
@@ -1,0 +1,9 @@
+class ModifyNotificationFrequencyForDecidimUsers < ActiveRecord::Migration[6.1]
+  def up
+    users = Decidim::User.where.not(notifications_sending_frequency: "none")
+    return if users.blank?
+
+    Rails.logger.info("Updating #{users.count} users to none frequency")
+    users.update_all(notifications_sending_frequency: "none")
+  end
+end


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

🚨  Create a migration to set Notification frequency to `none` for **all users in the database**. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- [Notion card](https://www.notion.so/opensourcepolitics/Toulouse-Recette-1-b8a712260fe74836a9a8836c2cfaa3cc?pvs=4)