### PR TITLE
Fix/sortable scopes in meetings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,7 +72,7 @@ GIT
 
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module_phone_authorization_handler
-  revision: 79f2a5f6c3357d63f92423a2b173893f4c4d06d8
+  revision: a3e77fb29e9a19793b3ff8b5d2273d41fac0919b
   branch: release/0.27-stable
   specs:
     decidim-phone_authorization_handler (1.0.0)
@@ -1096,6 +1096,7 @@ GEM
 PLATFORMS
   arm64-darwin-22
   x86_64-darwin-22
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/config/application.rb
+++ b/config/application.rb
@@ -54,6 +54,7 @@ module DevelopmentApp
       require "extends/commands/decidim/initiatives/admin/update_initiative_answer_extends"
       require "extends/controllers/decidim/initiatives/committee_requests_controller_extends"
       require "extends/models/decidim/budgets/project_extend"
+      require "extends/helpers/decidim/meetings/directory/application_helper_extends"
 
       Decidim::GraphiQL::Rails.config.tap do |config|
         config.initial_query = "{\n  deployment {\n    version\n    branch\n    remote\n    upToDate\n    currentCommit\n    latestCommit\n    locallyModified\n  }\n}".html_safe

--- a/lib/extends/helpers/decidim/meetings/directory/application_helper_extends.rb
+++ b/lib/extends/helpers/decidim/meetings/directory/application_helper_extends.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+module ApplicationHelperExtends
+  extend ActiveSupport::Concern
+  include Decidim::CheckBoxesTreeHelper
+
+  included do
+    def directory_filter_scopes_values
+      main_scopes = current_organization.scopes.top_level
+      scopes_values = main_scopes.includes(:scope_type, :children).sort_by(&:weight).flat_map do |scope|
+        TreeNode.new(
+          TreePoint.new(scope.id.to_s, translated_attribute(scope.name, current_organization)),
+          scope_children_to_tree(scope)
+        )
+      end
+
+      scopes_values.prepend(TreePoint.new("global", t("decidim.scopes.global")))
+
+      TreeNode.new(
+        TreePoint.new("", t("decidim.meetings.application_helper.filter_scope_values.all")),
+        scopes_values
+      )
+    end
+
+    def scope_children_to_tree(scope)
+      return unless scope.children.any?
+
+      scope.children.includes(:scope_type, :children).sort_by(&:weight).flat_map do |child|
+        TreeNode.new(
+          TreePoint.new(child.id.to_s, translated_attribute(child.name, current_organization)),
+          scope_children_to_tree(child)
+        )
+      end
+    end
+  end
+end
+
+Decidim::Meetings::Directory::ApplicationHelper.include(ApplicationHelperExtends)

--- a/spec/helpers/decidim/meetings/directory/application_helper_spec.rb
+++ b/spec/helpers/decidim/meetings/directory/application_helper_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Meetings
+    module Directory
+      describe ApplicationHelper do
+        let(:helper) do
+          Class.new(ActionView::Base) do
+            include ApplicationHelper
+            include CheckBoxesTreeHelper
+            include TranslatableAttributes
+          end.new(ActionView::LookupContext.new(ActionController::Base.view_paths), {}, [])
+        end
+        let!(:organization) { create(:organization) }
+        let!(:parent_scope) { create(:scope, organization: organization) }
+        let!(:scope_one) { create(:scope, organization: organization, parent: parent_scope, weight: 1) }
+        let!(:scope_two) { create(:scope, organization: organization, parent: parent_scope, weight: 2) }
+        let!(:scope_three) { create(:scope, organization: organization, parent: parent_scope, weight: 3) }
+
+        before do
+          allow(helper).to receive(:current_organization).and_return(organization)
+        end
+
+        describe "#directory_filter_scopes_values" do
+          let(:root) { helper.directory_filter_scopes_values }
+          let(:leaf) { root.leaf }
+          let(:nodes) { root.node }
+
+          context "when the organization has a scope with children" do
+            it "returns all the children ordered by weight" do
+              expect(root).to be_a(Decidim::CheckBoxesTreeHelper::TreeNode)
+              expect(nodes.last.node.count).to eq(3)
+              expect(nodes.last.node.first.leaf.label).to eq(scope_one.name["en"])
+              expect(nodes.last.node.last.leaf.label).to eq(scope_three.name["en"])
+            end
+
+            context "and the weight of scope's children changes" do
+              it "returns the children ordered by the new weight" do
+                scope_one.update(weight: 4)
+                expect(root).to be_a(Decidim::CheckBoxesTreeHelper::TreeNode)
+                expect(nodes.last.node.count).to eq(3)
+                expect(nodes.last.node.first.leaf.label).to eq(scope_two.name["en"])
+                expect(nodes.last.node.last.leaf.label).to eq(scope_one.name["en"])
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: Description
It allows scopes to be sorted in the filters of meetings index page

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?
- [Notion card](https://www.notion.so/opensourcepolitics/bd4bf860eab94f9daca7da803f09e3b2?v=c96df65755dd403d95e86f82d7749709&p=b35d25e8b1304ab3bc865ca4798c249e&pm=c)

#### Testing
Log in as admin
Access Backoffice
Go to settings
Access to scopes
Check that you can sort (sort and refresh to make sure everything stays in place)
Access onto a scope and try to sort the subscopes (same tests as above)
Go to the meetings index page
Check in the filters that the scopes are sorted in the same order as the one chosen by admin
You can repeat the process multiple times to check that it's always sorted correctly
