### PR TITLE
feat!: Rescue StandardError on migration fail

### DIFF
--- a/lib/tasks/decidim_app.rake
+++ b/lib/tasks/decidim_app.rake
@@ -43,7 +43,6 @@ namespace :decidim_app do
     # You can add your own customizations here
     desc "Upgrade decidim-app"
     task upgrade: :environment do
-      begin
       puts "Running upgrade db:migrate"
       Rake::Task["db:migrate"].invoke
 
@@ -51,11 +50,10 @@ namespace :decidim_app do
       Rake::Task["decidim:repair:url_in_content"].invoke
       puts "Running decidim:repair:translations"
       Rake::Task["decidim:repair:translations"].invoke
-      rescue => e
-        puts "Ignoring error: #{e.message}"
-        puts "Running decidim:db:migrate"
-        Rake::Task["decidim:db:migrate"].invoke
-        end
+    rescue StandardError => e
+      puts "Ignoring error: #{e.message}"
+      puts "Running decidim:db:migrate"
+      Rake::Task["decidim:db:migrate"].invoke
     end
 
     desc "usage: bundle exec rails k8s:dump_db"

--- a/lib/tasks/decidim_app.rake
+++ b/lib/tasks/decidim_app.rake
@@ -33,7 +33,8 @@ namespace :decidim_app do
     # You can add your own customizations here
     desc "Install decidim-app"
     task install: :environment do
-      puts "Running decidim:db:migrate"
+      puts "Running install :db:migrate"
+      Rake::Task["db:migrate"].invoke
       Rake::Task["decidim:db:migrate"].invoke
     end
 
@@ -42,12 +43,19 @@ namespace :decidim_app do
     # You can add your own customizations here
     desc "Upgrade decidim-app"
     task upgrade: :environment do
-      puts "Running decidim:db:migrate"
-      Rake::Task["decidim:db:migrate"].invoke
+      begin
+      puts "Running upgrade db:migrate"
+      Rake::Task["db:migrate"].invoke
+
       puts "Running decidim:repair:url_in_content"
       Rake::Task["decidim:repair:url_in_content"].invoke
       puts "Running decidim:repair:translations"
       Rake::Task["decidim:repair:translations"].invoke
+      rescue => e
+        puts "Ignoring error: #{e.message}"
+        puts "Running decidim:db:migrate"
+        Rake::Task["decidim:db:migrate"].invoke
+        end
     end
 
     desc "usage: bundle exec rails k8s:dump_db"

--- a/lib/tasks/decidim_app.rake
+++ b/lib/tasks/decidim_app.rake
@@ -18,7 +18,7 @@ namespace :decidim_app do
       puts "Missing migrations :
 #{migrations}"
       puts "Applying missing migrations..."
-      system("bundle exec rake db:migrate")
+      system("bundle exec rake decidim:db:migrate")
     else
       puts "All migrations are up"
     end
@@ -33,8 +33,8 @@ namespace :decidim_app do
     # You can add your own customizations here
     desc "Install decidim-app"
     task install: :environment do
-      puts "Running db:migrate"
-      Rake::Task["db:migrate"].invoke
+      puts "Running decidim:db:migrate"
+      Rake::Task["decidim:db:migrate"].invoke
     end
 
     # This task is used to upgrade your decidim-app to the latest version
@@ -42,8 +42,8 @@ namespace :decidim_app do
     # You can add your own customizations here
     desc "Upgrade decidim-app"
     task upgrade: :environment do
-      puts "Running db:migrate"
-      Rake::Task["db:migrate"].invoke
+      puts "Running decidim:db:migrate"
+      Rake::Task["decidim:db:migrate"].invoke
       puts "Running decidim:repair:url_in_content"
       Rake::Task["decidim:repair:url_in_content"].invoke
       puts "Running decidim:repair:translations"


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

Rescue `StandardError` when migration fails and run `decidim:db:migrate`  instead

