### PR TITLE
feat: Migration to fix registration metadata

### DIFF
--- a/db/migrate/20240521130556_modify_decidim_users_registration_metadata.rb
+++ b/db/migrate/20240521130556_modify_decidim_users_registration_metadata.rb
@@ -1,0 +1,53 @@
+class ModifyDecidimUsersRegistrationMetadata < ActiveRecord::Migration[6.1]
+  REGISTRATION_METADATA_BIRTH_DATE = "birth_date"
+  REGISTRATION_METADATA_GENDER = "gender"
+  EXTENDED_DATA_BIRTH_DATE = "date_of_birth"
+  EXTENDED_DATA_GENDER = "gender"
+  DAY_OF_BIRTH = "01"
+
+  # This migration modifies the extended_data of the users
+  # It copies birth_date and gender from registration_metadata to extended_data
+  # This migration don't destroy any data
+  # If the user has already the extended_data keys, it will not be modified
+  # If the user has extended_data modified, a key migrated_at is added in json
+  # example:
+  # registration_metadata = {"gender"=>"female", "birth_date"=>{"year"=>"1973", "month"=>"March"}}
+  # extended_data = {"gender"=>"female", "date_of_birth"=>"1973-03-01", "migrated_at"=>"2024-05-21 16:07:29 +0200"}
+  def up
+    Decidim::User.find_each do |user|
+      registration_metadata = user.registration_metadata || {}
+      extended_data = {}
+      extended_data.merge!(gender(registration_metadata, user.extended_data))
+      extended_data.merge!(birth_date(registration_metadata, user.extended_data))
+
+      if user.extended_data != extended_data
+        user.extended_data = extended_data
+        user.extended_data.merge!("migrated_at" => Time.zone.now.to_s)
+
+        user.save!
+      end
+    end
+  end
+
+  private
+
+  def gender(source, extended_data)
+    return {} if source.blank?
+    return {} if source.fetch(REGISTRATION_METADATA_GENDER, nil).blank?
+    return {} if extended_data&.fetch(EXTENDED_DATA_GENDER, nil).present?
+
+    { REGISTRATION_METADATA_GENDER => source.fetch(EXTENDED_DATA_GENDER) }
+  end
+
+  def birth_date(source, extended_data)
+    return {} if source.blank?
+    return {} if source.fetch(REGISTRATION_METADATA_BIRTH_DATE, nil).blank?
+    return {} if extended_data&.fetch(EXTENDED_DATA_BIRTH_DATE, nil).present?
+
+    birth_year = source.dig(REGISTRATION_METADATA_BIRTH_DATE, "year").presence || Time.zone.now.year
+    birth_month = source.dig(REGISTRATION_METADATA_BIRTH_DATE, "month").presence || Time.zone.now.month
+    birth_date = "#{birth_year}-#{birth_month}-#{DAY_OF_BIRTH}"
+
+    { EXTENDED_DATA_BIRTH_DATE => birth_date }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_05_02_141959) do
+ActiveRecord::Schema.define(version: 2024_05_21_130556) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -1478,8 +1478,8 @@ ActiveRecord::Schema.define(version: 2024_05_02_141959) do
     t.float "latitude"
     t.float "longitude"
     t.boolean "display_linked_assemblies", default: false
-    t.text "emitter_name"
     t.bigint "decidim_participatory_process_type_id"
+    t.text "emitter_name"
     t.index ["decidim_area_id"], name: "index_decidim_participatory_processes_on_decidim_area_id"
     t.index ["decidim_organization_id", "slug"], name: "index_unique_process_slug_and_organization", unique: true
     t.index ["decidim_organization_id"], name: "index_decidim_processes_on_decidim_organization_id"


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

Copy users `registration_metadata` to `extended_data` to make the extra user fields and customizations compatible.

#### :pushpin: Related Issues
*Link your PR to an issue*
- [Notion card](https://www.notion.so/opensourcepolitics/Toulouse-Migration-sign-up-form-5f9ddaa297f14f3fa2a70ff985fb4e31?pvs=4)

```
  # example:
  # registration_metadata = {"gender"=>"female", "birth_date"=>{"year"=>"1973", "month"=>"March"}}
  # extended_data = {"gender"=>"female", "date_of_birth"=>"1973-03-01", "migrated_at"=>"2024-05-21 16:07:29 +0200"}
```

#### Tasks
- [x] Add migration

🚨 **This PR modify data through Rails migration. Data should only be copied and a field `modified_at` is present on each record where `extended_data` has been updated**
