### PR TITLE
fix: Add Rake task to fix birth date

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1478,8 +1478,8 @@ ActiveRecord::Schema.define(version: 2024_05_21_130556) do
     t.float "latitude"
     t.float "longitude"
     t.boolean "display_linked_assemblies", default: false
-    t.bigint "decidim_participatory_process_type_id"
     t.text "emitter_name"
+    t.bigint "decidim_participatory_process_type_id"
     t.index ["decidim_area_id"], name: "index_decidim_participatory_processes_on_decidim_area_id"
     t.index ["decidim_organization_id", "slug"], name: "index_unique_process_slug_and_organization", unique: true
     t.index ["decidim_organization_id"], name: "index_decidim_processes_on_decidim_organization_id"

--- a/lib/tasks/repair_data.rake
+++ b/lib/tasks/repair_data.rake
@@ -70,5 +70,23 @@ namespace :decidim do
         end
       end
     end
+
+    desc "Fix birth_date in user extended_data"
+    task birth_date: :environment do
+      Decidim::User.find_each do |user|
+        date_of_birth = user.extended_data&.fetch("date_of_birth", "")
+        next if date_of_birth.blank?
+
+        begin
+          birth_date = Date.parse(date_of_birth).strftime("%Y-%m-%d")
+        rescue ArgumentError
+          next
+        end
+        if date_of_birth != birth_date
+          user.extended_data["date_of_birth"] = birth_date
+          user.save!
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

In `extended_data` field on `Decidim::User`, birth date are formatted as follow : `2000-January-01`, this rake task will update each record as follow `2000-01-01`

`bundle exec rake decidim:repair:birth_date`