### PR TITLE
fix(i18n): bump modules for fr budget translations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,7 +58,7 @@ GIT
 
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-half_sign_up.git
-  revision: 5d7db7919e9a58ad2623137d6758565ac4739064
+  revision: 5f24e2cd183767e48c390b0fc2064c5544f60c49
   branch: feature/half_signup_and_budgets_booth
   specs:
     decidim-half_signup (0.27.0)
@@ -111,7 +111,7 @@ GIT
 
 GIT
   remote: https://github.com/Pipeline-to-Power/decidim-module-ptp.git
-  revision: 18c7422633b743ff6fe63e1dda90bb3480d741a8
+  revision: 31516827c0836410e5efa1d7e1f93074d86ca201
   branch: main
   specs:
     decidim-budgets_booth (0.27.0)


### PR DESCRIPTION
#### :tophat: Description
Bump decidim-module-half_sign_up and decidim-module-ptp modules for corrected fr translations

#### see 
- https://github.com/OpenSourcePolitics/decidim-module-half_sign_up/pull/32
- https://github.com/OpenSourcePolitics/decidim-module-ptp/pull/7
- https://github.com/OpenSourcePolitics/decidim-module-ptp/pull/8
- https://github.com/OpenSourcePolitics/decidim-module-ptp/pull/9
