### PR TITLE
fix: don't validate phone number uniqueness if nil

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,7 @@ GIT
 
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-half_sign_up.git
-  revision: ff583236c405e14e072e91476b54170d4360c39c
+  revision: c23334e721cd9a6b1d43ae72fc9b6a4387334c9f
   branch: feature/half_signup_and_budgets_booth
   specs:
     decidim-half_signup (0.27.0)


### PR DESCRIPTION
Bump `decidim-module-half_sign_up` [#39](https://github.com/OpenSourcePolitics/decidim-module-half_sign_up/pull/39)
> The validation was preventing `Decidim::User` to be saved when the `phone_number` attribute is `nil`. 