### PR TITLE
feat: Activate open data route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,6 @@ Rails.application.routes.draw do
   end
 
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development? || ENV.fetch("ENABLE_LETTER_OPENER", "0") == "1"
-  get "/open-data/download", to: redirect("/404")
 
   mount Decidim::Core::Engine => "/"
   # mount Decidim::Map::Engine => '/map'


### PR DESCRIPTION
#### :tophat: Description
Revert of the following commit https://github.com/OpenSourcePolitics/decidim-tou/commit/79154e4544aa4aa3f42724a8beabd4cfe04bbdf5 to reactive the OpenData route on decidim-tou. 

#### Testing
* Try to download the OpenData file 
⚠️ You might have to comment ou remove the `decidim-phone_authorization_handler` gem to test opendata locally with seeds 