### PR TITLE
Backport seven zip as cli wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ run: up
 	@make create-seeds
 
 up: build
-	docker-compose -f docker-compose.local.yml up -d
+	docker compose -f docker-compose.local.yml up -d
 	@make setup-database
 
 build:
@@ -12,33 +12,33 @@ build:
 
 # Stops containers and remove volumes
 teardown:
-	docker-compose -f docker-compose.local.yml down -v --rmi all
+	docker compose -f docker-compose.local.yml down -v --rmi all
 
 create-database:
-	docker-compose -f docker-compose.local.yml exec app /bin/bash -c 'DISABLE_DATABASE_ENVIRONMENT_CHECK=1 /usr/local/bundle/bin/bundle exec rake db:create'
+	docker compose -f docker-compose.local.yml exec app /bin/bash -c 'DISABLE_DATABASE_ENVIRONMENT_CHECK=1 /usr/local/bundle/bin/bundle exec rake db:create'
 
 setup-database: create-database
-	docker-compose -f docker-compose.local.yml exec app /bin/bash -c 'DISABLE_DATABASE_ENVIRONMENT_CHECK=1 /usr/local/bundle/bin/bundle exec rake db:migrate'
+	docker compose -f docker-compose.local.yml exec app /bin/bash -c 'DISABLE_DATABASE_ENVIRONMENT_CHECK=1 /usr/local/bundle/bin/bundle exec rake db:migrate'
 
 # Create seeds
 create-seeds:
-	docker-compose -f docker-compose.local.yml exec app /bin/bash -c 'DISABLE_DATABASE_ENVIRONMENT_CHECK=1 /usr/local/bundle/bin/bundle exec rake db:schema:load db:seed'
+	docker compose -f docker-compose.local.yml exec app /bin/bash -c 'DISABLE_DATABASE_ENVIRONMENT_CHECK=1 /usr/local/bundle/bin/bundle exec rake db:schema:load db:seed'
 
 # Restore dump
 restore-dump:
 	bundle exec rake restore_dump
 
 shell:
-	docker-compose -f docker-compose.local.yml exec app /bin/bash
+	docker compose -f docker-compose.local.yml exec app /bin/bash
 
 restart:
-	docker-compose -f docker-compose.local.yml up -d
+	docker compose -f docker-compose.local.yml up -d
 
 status:
-	docker-compose -f docker-compose.local.yml ps
+	docker compose -f docker-compose.local.yml ps
 
 logs:
-	docker-compose -f docker-compose.local.yml logs app
+	docker compose -f docker-compose.local.yml logs app
 
 external:
 	@if [ -z "$(IP)" ]; then \
@@ -46,11 +46,11 @@ external:
     		echo "You can discover your IP as follow : \n > ifconfig | grep netmask | grep -v 127.0.0.1 | awk '{print \$$2}' | tail -n1"; \
     		exit 1; \
 	fi
-	docker-compose -f docker-compose.local.yml exec app /bin/bash -c 'DISABLE_DATABASE_ENVIRONMENT_CHECK=1 /usr/local/bundle/bin/bundle exec rails runner "puts Decidim::Organization.first.update(host: \"$(IP)\")"'; \
+	docker compose -f docker-compose.local.yml exec app /bin/bash -c 'DISABLE_DATABASE_ENVIRONMENT_CHECK=1 /usr/local/bundle/bin/bundle exec rails runner "puts Decidim::Organization.first.update(host: \"$(IP)\")"'; \
 	echo "Decidim organization host updated to $(IP)"; \
 	echo "App is now accessible at https://$(IP):3000";
 
 rebuild:
-	docker-compose -f docker-compose.local.yml down
+	docker compose -f docker-compose.local.yml down
 	docker volume rm ${IMAGE_NAME}_shared-volume || true
 	@make up

--- a/app/services/decidim/download_your_data_exporter.rb
+++ b/app/services/decidim/download_your_data_exporter.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "decidim/seven_zip_wrapper"
+
+module Decidim
+  # Public: Generates a 7z(seven zip) file with data files ready to be persisted
+  # somewhere so users can download their data.
+  #
+  # In fact, the 7z file wraps a ZIP file which finally contains the data files.
+  class DownloadYourDataExporter
+
+    DEFAULT_EXPORT_FORMAT = "CSV"
+    ZIP_FILE_NAME = "download-your-data.zip"
+
+    # Public: Initializes the class.
+    #
+    # user          - The user to export the data from.
+    # path          - The String path where to write the zip file.
+    # password      - The password to protect the zip file.
+    # export_format - The format of the data files inside the zip file. (CSV by default)
+    def initialize(user, path, password, export_format = DEFAULT_EXPORT_FORMAT)
+      @user = user
+      @path = File.expand_path path
+      @export_format = export_format
+      @password = password
+    end
+
+    def export
+      #Rails.logger.debug "EXPORTDATA export_format variable is #{@export_format}"
+      tmpdir = Dir.mktmpdir("temporary-download-your-data-dir")
+      #Rails.logger.debug "EXPORTDATA tmpdir variable is #{tmpdir}"
+      user_data, user_attachments = data_and_attachments_for_user
+      save_user_data(tmpdir, user_data)
+      save_user_attachments(tmpdir, user_attachments)
+
+      SevenZipWrapper.compress_and_encrypt(filename: @path, password: @password, input_directory: tmpdir)
+    end
+
+    private
+
+    attr_reader :user, :export_format
+
+    def data_and_attachments_for_user
+      export_data = []
+      export_attachments = []
+      download_your_data_entities.each do |object|
+        klass = Object.const_get(object)
+        export_data << [klass.model_name.name.parameterize.pluralize, Exporters.find_exporter(export_format).new(klass.user_collection(user), klass.export_serializer).export]
+        attachments = klass.download_your_data_images(user)
+        export_attachments << [klass.model_name.name.parameterize.pluralize, attachments.flatten] unless attachments.nil?
+      end
+
+      [export_data, export_attachments]
+    end
+
+    def download_your_data_entities
+      @download_your_data_entities ||= DownloadYourDataSerializers.data_entities
+    end
+
+    def save_user_data(tmpdir, user_data)
+      user_data.each do |entity, exporter_data|
+        next if exporter_data.read == "\n"
+
+        file_name = File.join(tmpdir, "#{entity}-#{exporter_data.filename}")
+        File.write(file_name, exporter_data.read)
+      end
+    end
+
+    def save_user_attachments(tmpdir, user_attachments)
+      user_attachments.each do |entity, attachment_block|
+        attachment_block.each do |attachment|
+          next unless attachment.attached?
+
+          blobs = attachment.is_a?(ActiveStorage::Attached::One) ? [attachment.blob] : attachment.blobs
+          blobs.each do |blob|
+            Dir.mkdir(File.join(tmpdir, entity.parameterize))
+            file_name = File.join(tmpdir, entity.parameterize, blob.filename.to_s)
+            blob.open do |blob_file|
+              File.write(file_name, blob_file.read.force_encoding("UTF-8"))
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/decidim/download_your_data_exporter.rb
+++ b/app/services/decidim/download_your_data_exporter.rb
@@ -8,7 +8,6 @@ module Decidim
   #
   # In fact, the 7z file wraps a ZIP file which finally contains the data files.
   class DownloadYourDataExporter
-
     DEFAULT_EXPORT_FORMAT = "CSV"
     ZIP_FILE_NAME = "download-your-data.zip"
 
@@ -26,9 +25,7 @@ module Decidim
     end
 
     def export
-      #Rails.logger.debug "EXPORTDATA export_format variable is #{@export_format}"
       tmpdir = Dir.mktmpdir("temporary-download-your-data-dir")
-      #Rails.logger.debug "EXPORTDATA tmpdir variable is #{tmpdir}"
       user_data, user_attachments = data_and_attachments_for_user
       save_user_data(tmpdir, user_data)
       save_user_attachments(tmpdir, user_attachments)

--- a/app/services/decidim/download_your_data_exporter.rb
+++ b/app/services/decidim/download_your_data_exporter.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "decidim/seven_zip_wrapper"
-require 'fileutils'
 
 module Decidim
   # Public: Generates a 7z(seven zip) file with data files ready to be persisted

--- a/app/services/decidim/download_your_data_exporter.rb
+++ b/app/services/decidim/download_your_data_exporter.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "decidim/seven_zip_wrapper"
+require 'fileutils'
 
 module Decidim
   # Public: Generates a 7z(seven zip) file with data files ready to be persisted

--- a/config/application.rb
+++ b/config/application.rb
@@ -56,6 +56,7 @@ module DevelopmentApp
       require "extends/models/decidim/budgets/project_extend"
       require "extends/commands/decidim/budgets/admin/import_proposals_to_budgets_extends"
       require "extends/helpers/decidim/meetings/directory/application_helper_extends"
+      require "extends/comments/comment_serializer_extends"
 
       Decidim::GraphiQL::Rails.config.tap do |config|
         config.initial_query = "{\n  deployment {\n    version\n    branch\n    remote\n    upToDate\n    currentCommit\n    latestCommit\n    locallyModified\n  }\n}".html_safe

--- a/config/application.rb
+++ b/config/application.rb
@@ -57,6 +57,7 @@ module DevelopmentApp
       require "extends/commands/decidim/budgets/admin/import_proposals_to_budgets_extends"
       require "extends/helpers/decidim/meetings/directory/application_helper_extends"
       require "extends/comments/comment_serializer_extends"
+      require "extends/comments/comment_vote_serializer_extends"
 
       Decidim::GraphiQL::Rails.config.tap do |config|
         config.initial_query = "{\n  deployment {\n    version\n    branch\n    remote\n    upToDate\n    currentCommit\n    latestCommit\n    locallyModified\n  }\n}".html_safe

--- a/lib/decidim/seven_zip_wrapper.rb
+++ b/lib/decidim/seven_zip_wrapper.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "shellwords"
+
+module Decidim
+  class SevenZipWrapper
+    class << self
+      def compress_and_encrypt(filename:, password:, input_directory:)
+        run("cd #{escape(input_directory)} && 7z a -tzip -p#{escape(password)} -mem=AES256 #{escape(filename)} .")
+      end
+
+      def extract_and_decrypt(filename:, password:, output_directory:)
+        run("7z x -tzip #{escape(filename)} -o#{escape(output_directory)} -p#{escape(password)}")
+      end
+
+      private
+
+      def run(command)
+        success = system(command)
+
+        raise "Command failed: #{command}" unless success
+      end
+
+      def escape(string)
+        Shellwords.escape(string)
+      end
+    end
+  end
+end

--- a/lib/extends/comments/comment_serializer_extends.rb
+++ b/lib/extends/comments/comment_serializer_extends.rb
@@ -1,0 +1,17 @@
+require "active_support/concern"
+
+module CommentSerializerExtends
+  extend ActiveSupport::Concern
+
+  included do
+    def root_commentable_url
+      @root_commentable_url ||= if resource.root_commentable.respond_to?(:polymorphic_resource_url)
+                                  resource.root_commentable.polymorphic_resource_url({})
+                                else
+                                  Decidim::ResourceLocatorPresenter.new(resource.root_commentable).url
+                                end
+    end
+  end
+end
+
+Decidim::Comments::CommentSerializer.include(CommentSerializerExtends)

--- a/lib/extends/comments/comment_serializer_extends.rb
+++ b/lib/extends/comments/comment_serializer_extends.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/concern"
 
 module CommentSerializerExtends

--- a/lib/extends/comments/comment_vote_serializer_extends.rb
+++ b/lib/extends/comments/comment_vote_serializer_extends.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module CommentVoteSerializerExtends
+  extend ActiveSupport::Concern
+
+  included do
+    def root_commentable_url
+      @root_commentable_url ||= if resource.comment.root_commentable.respond_to?(:polymorphic_resource_url)
+                                  resource.comment.root_commentable.polymorphic_resource_url({})
+                                else
+                                  Decidim::ResourceLocatorPresenter.new(resource.comment.root_commentable).url
+                                end
+    end
+  end
+end
+
+Decidim::Comments::CommentVoteSerializer.include(CommentVoteSerializerExtends)

--- a/spec/services/decidim/download_your_data_exporter_spec.rb
+++ b/spec/services/decidim/download_your_data_exporter_spec.rb
@@ -1,0 +1,95 @@
+require "spec_helper"
+require "decidim/seven_zip_wrapper"
+
+module Decidim
+  describe DownloadYourDataExporter do
+    subject { DownloadYourDataExporter.new(user, tmp_file_in, password) }
+
+    let(:tmp_file_in) do
+      Dir::Tmpname.create(["download-your-data", ".7z"]) do
+        # just get an empty file name
+      end
+    end
+    let(:tmp_dir_out) { Dir.mktmpdir("download_your_data_exporter_spec") }
+    let(:password) { "download-your-data.7z>passwd" }
+    let(:organization) { create(:organization) }
+    let(:user) { create :user, organization: organization }
+    let(:expected_files) do
+      # this are the prefixes for the files that could have user generated content
+      %w(
+        decidim-follows-
+        decidim-identities-
+        decidim-messaging-conversations-
+        decidim-notifications-
+        decidim-participatoryspaceprivateusers-
+        decidim-reports-
+        decidim-users-
+        decidim-usergroups-
+        decidim-meetings-registrations-
+        decidim-proposals-proposals-
+        decidim-budgets-orders-
+        decidim-forms-answers-
+        decidim-debates-debates-
+        decidim-conferences-conferenceregistrations-
+        decidim-conferences-conferenceinvites-
+        decidim-comments-comments-
+        decidim-comments-commentvotes-
+      )
+    end
+
+    describe "#export" do
+      it "compresses a password protected file" do
+        expect(File.exist?(tmp_file_in)).to be false
+
+        # generate 7z
+        subject.export
+
+        expect(File.exist?(tmp_file_in)).to be true
+
+        open_7z_and_extract_zip(tmp_file_in)
+
+        expect(Dir.entries(tmp_dir_out).count).to eq 4
+      end
+    end
+
+    describe "#data_and_attachments_for_user" do
+      it "returns an array of data for the user" do
+        user_data, = subject.send(:data_and_attachments_for_user)
+
+        file_prefixes = expected_files.dup
+        user_data.each do |entity, exporter_data|
+          entity_prefix = file_prefixes.find { |prefix| prefix.start_with?(entity) }
+          expect(file_prefixes.delete(entity_prefix)).to be_present
+
+          # we have an empty file  for each entity except for decidim-users
+          expect(exporter_data.read).to eq("\n") unless entity == "decidim-users"
+        end
+        expect(file_prefixes).to be_empty
+      end
+
+      context "when the user has a comment" do
+        let(:participatory_space) { create(:participatory_process, organization: organization) }
+        let(:component) { create(:component, participatory_space: participatory_space) }
+        let(:commentable) { create(:dummy_resource, component: component) }
+        let!(:comment) { create(:comment, commentable: commentable, author: user) }
+
+        it "returns the comment data" do
+          user_data, = subject.send(:data_and_attachments_for_user)
+
+          user_data.find { |entity, _| entity == "decidim-comments-comments" }.tap do |_, exporter_data|
+            csv_comments = exporter_data.read.split("\n")
+            expect(csv_comments.count).to eq 2
+            expect(csv_comments.first).to start_with "id;created_at;body;locale;author/id;author/name;alignment;depth;"
+            expect(csv_comments.second).to start_with "#{comment.id};"
+          end
+        end
+      end
+    end
+
+    private
+
+    def open_7z_and_extract_zip(file_path)
+      SevenZipWrapper.extract_and_decrypt(filename: file_path, password: password, output_directory: tmp_dir_out)
+    end
+  end
+end

--- a/spec/services/decidim/download_your_data_exporter_spec.rb
+++ b/spec/services/decidim/download_your_data_exporter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "decidim/seven_zip_wrapper"
 

--- a/spec/shared/has_questionnaire.rb
+++ b/spec/shared/has_questionnaire.rb
@@ -105,10 +105,9 @@ shared_examples_for "has questionnaire" do
 
     it "requires confirmation when exiting mid-answering" do
       visit questionnaire_public_path
-
       fill_in question.body["en"], with: "My first answer"
       find(".logo-wrapper a").click
-      wait = Selenium::WebDriver::Wait.new ignore: Selenium::WebDriver::Error::NoSuchAlertError
+      wait = Selenium::WebDriver::Wait.new ignore: Selenium::WebDriver::Error::NoSuchAlertError, timeout: 10
       alert = wait.until { page.driver.browser.switch_to.alert }
       alert.dismiss
 

--- a/spec/shared/has_questionnaire.rb
+++ b/spec/shared/has_questionnaire.rb
@@ -109,7 +109,6 @@ shared_examples_for "has questionnaire" do
       fill_in question.body["en"], with: "My first answer"
 
       dismiss_page_unload do
-        sleep 2
         page.find(".logo-wrapper a").click
       end
 

--- a/spec/shared/has_questionnaire.rb
+++ b/spec/shared/has_questionnaire.rb
@@ -108,8 +108,9 @@ shared_examples_for "has questionnaire" do
 
       fill_in question.body["en"], with: "My first answer"
       find(".logo-wrapper a").click
-      confirm = page.driver.browser.switch_to.alert
-      confirm.dismiss
+      wait = Selenium::WebDriver::Wait.new ignore: Selenium::WebDriver::Error::NoSuchAlertError
+      alert = wait.until { page.driver.browser.switch_to.alert }
+      alert.dismiss
 
       expect(page).to have_current_path questionnaire_public_path
     end

--- a/spec/shared/has_questionnaire.rb
+++ b/spec/shared/has_questionnaire.rb
@@ -105,11 +105,12 @@ shared_examples_for "has questionnaire" do
 
     it "requires confirmation when exiting mid-answering" do
       visit questionnaire_public_path
+
       fill_in question.body["en"], with: "My first answer"
-      find(".logo-wrapper a").click
-      wait = Selenium::WebDriver::Wait.new ignore: Selenium::WebDriver::Error::NoSuchAlertError, timeout: 10
-      alert = wait.until { page.driver.browser.switch_to.alert }
-      alert.dismiss
+
+      dismiss_page_unload do
+        page.find(".logo-wrapper a").click
+      end
 
       expect(page).to have_current_path questionnaire_public_path
     end

--- a/spec/shared/has_questionnaire.rb
+++ b/spec/shared/has_questionnaire.rb
@@ -109,6 +109,7 @@ shared_examples_for "has questionnaire" do
       fill_in question.body["en"], with: "My first answer"
 
       dismiss_page_unload do
+        sleep 2
         page.find(".logo-wrapper a").click
       end
 

--- a/spec/shared/has_questionnaire.rb
+++ b/spec/shared/has_questionnaire.rb
@@ -107,10 +107,9 @@ shared_examples_for "has questionnaire" do
       visit questionnaire_public_path
 
       fill_in question.body["en"], with: "My first answer"
-
-      dismiss_page_unload do
-        find("a.process-nav__link", match: :first).click
-      end
+      find(".logo-wrapper a").click
+      confirm = page.driver.browser.switch_to.alert
+      confirm.dismiss
 
       expect(page).to have_current_path questionnaire_public_path
     end

--- a/spec/shared/has_questionnaire.rb
+++ b/spec/shared/has_questionnaire.rb
@@ -6,7 +6,6 @@ shared_examples_for "has questionnaire" do
   context "when the user is not logged in" do
     it "does not allow answering the questionnaire" do
       visit questionnaire_public_path
-
       expect(page).to have_i18n_content(questionnaire.title, upcase: true)
       expect(page).to have_i18n_content(questionnaire.description)
 
@@ -110,7 +109,7 @@ shared_examples_for "has questionnaire" do
       fill_in question.body["en"], with: "My first answer"
 
       dismiss_page_unload do
-        page.find(".logo-wrapper a").click
+        find("a.process-nav__link", match: :first).click
       end
 
       expect(page).to have_current_path questionnaire_public_path

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,12 +10,15 @@ Capybara.register_driver :headless_chrome do |app|
   options = ::Selenium::WebDriver::Chrome::Options.new
   options.args << "--headless=new"
   options.args << "--no-sandbox"
+  options.args << "--disable-gpu"
+  options.args << "--disable-popup-blocking"
   options.args << if ENV["BIG_SCREEN_SIZE"].present?
                     "--window-size=1920,3000"
                   else
                     "--window-size=1920,1080"
                   end
   options.args << "--ignore-certificate-errors" if ENV["TEST_SSL"]
+  options.add_preference("intl.accept_languages", "en-GB")
   Capybara::Selenium::Driver.new(
     app,
     browser: :chrome,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,15 +10,13 @@ Capybara.register_driver :headless_chrome do |app|
   options = ::Selenium::WebDriver::Chrome::Options.new
   options.args << "--headless=new"
   options.args << "--no-sandbox"
-  options.args << "--disable-gpu"
-  options.args << "--disable-popup-blocking"
   options.args << if ENV["BIG_SCREEN_SIZE"].present?
                     "--window-size=1920,3000"
                   else
                     "--window-size=1920,1080"
                   end
   options.args << "--ignore-certificate-errors" if ENV["TEST_SSL"]
-  options.add_preference("intl.accept_languages", "en-GB")
+
   Capybara::Selenium::Driver.new(
     app,
     browser: :chrome,


### PR DESCRIPTION
#### :tophat: Description
When I load my personal data, I receive an email with a zip file and a password to open it. The password is now functional, I can open the file and access my personal data.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to issue https://github.com/decidim/decidim/issues/13037
- [Notion card](https://www.notion.so/opensourcepolitics/bd4bf860eab94f9daca7da803f09e3b2?v=c96df65755dd403d95e86f82d7749709&p=54547f3ef83a4d1e806cdeee4a43cf60&pm=c)
- backport de https://github.com/decidim/decidim/pull/13185/files

#### Testing
After login, go to "My account"
Go to "My data"
Click on "Request data"
Go to you mail and download the zip file
Open the zip file and enter the password provided in the mail
See that you open the zip and access to your personal data file

