### PR TITLE
fix: Export issue for Processes Administrators

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -6,6 +6,7 @@ env:
   SIMPLECOV: "true"
   RSPEC_FORMAT: "documentation"
   RUBY_VERSION: 3.0.6
+  CHROME_VERSION: 126.0.6478.182
   RAILS_ENV: test
   NODE_VERSION: 16.9.1
   RUBYOPT: '-W:no-deprecated'
@@ -87,6 +88,11 @@ jobs:
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
+      - run: |
+          wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${{env.CHROME_VERSION}}-1_amd64.deb
+          sudo dpkg -i /tmp/chrome.deb
+          rm /tmp/chrome.deb
+        name: Install Chrome version ${{ env.CHROME_VERSION }}
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -105,6 +111,8 @@ jobs:
       - run: mkdir -p ./spec/tmp/screenshots
         name: Create the screenshots folder
       - uses: nanasess/setup-chromedriver@v2
+        with:
+          chromedriver-version: ${{ env.CHROME_VERSION }}
       - run:  bundle exec rake "test:run[exclude, spec/system/**/*_spec.rb, ${{ matrix.slice }}]"
         name: RSpec
       # - run: ./.github/upload_coverage.sh decidim-app $GITHUB_EVENT_PATH
@@ -171,6 +179,8 @@ jobs:
       - run: mkdir -p ./spec/tmp/screenshots
         name: Create the screenshots folder
       - uses: nanasess/setup-chromedriver@v2
+        with:
+          chromedriver-version: ${{ env.CHROME_VERSION }}
       - run:  bundle exec rake "test:run[include, spec/system/**/*_spec.rb, ${{ matrix.slice }}]"
         name: RSpec
       # - run: ./.github/upload_coverage.sh decidim-app $GITHUB_EVENT_PATH

--- a/app/jobs/decidim/export_job.rb
+++ b/app/jobs/decidim/export_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Decidim
+  class ExportJob < ApplicationJob
+    queue_as :exports
+
+    def perform(user, component, name, format, resource_id = nil)
+      export_manifest = component.manifest.export_manifests.find do |manifest|
+        manifest.name == name.to_sym
+      end
+
+      collection = export_manifest.collection.call(component, user, resource_id)
+      serializer = export_manifest.serializer
+
+      export_data = if (serializer == Decidim::Proposals::ProposalSerializer) && (user.admin? || admin_of_process?(user, component))
+                      Decidim::Exporters.find_exporter(format).new(collection, serializer).admin_export
+                    else
+                      Decidim::Exporters.find_exporter(format).new(collection, serializer).export
+                    end
+      ExportMailer.export(user, name, export_data).deliver_now
+    end
+
+    private
+
+    def admin_of_process?(user, component)
+      return unless component.respond_to?(:participatory_space)
+
+      Decidim::ParticipatoryProcessUserRole.exists?(decidim_user_id: user.id, decidim_participatory_process_id: component.participatory_space.id, role: "admin")
+    end
+  end
+end

--- a/config/initializers/extends.rb
+++ b/config/initializers/extends.rb
@@ -3,3 +3,4 @@
 require "extends/controllers/decidim/devise/account_controller_extends"
 require "extends/cells/decidim/content_blocks/hero_cell_extends"
 require "extends/uploaders/decidim/application_uploader_extends"
+require "extends/lib/decidim/phone_authorization_handler/proposal_serializer_extend"

--- a/lib/extends/lib/decidim/phone_authorization_handler/proposal_serializer_extend.rb
+++ b/lib/extends/lib/decidim/phone_authorization_handler/proposal_serializer_extend.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module ProposalSerializerExtend
+  def author_metadata
+    author_metadata = {
+      name: "",
+      nickname: "",
+      email: "",
+      phone_number: ""
+    }
+
+    if proposal.creator.decidim_author_type == "Decidim::UserBaseEntity"
+      begin
+        user = Decidim::User.find(proposal.creator_author.id)
+        author_metadata[:name] = user.try(:name).presence || ""
+        author_metadata[:nickname] = user.try(:nickname).presence || ""
+        author_metadata[:email] = user.try(:email).presence || ""
+        author_metadata[:phone_number] = phone_number(user.id)
+      rescue ActiveRecord::RecordNotFound => e
+        Rails.logger.error "User not found: #{e.message}"
+        author_metadata[:name] = ""
+        author_metadata[:nickname] = ""
+        author_metadata[:email] = ""
+        author_metadata[:phone_number] = ""
+      end
+    end
+
+    author_metadata
+  end
+end
+
+Decidim::PhoneAuthorizationHandler::Extends::ProposalSerializerExtend.prepend(ProposalSerializerExtend)

--- a/spec/jobs/export_job_spec.rb
+++ b/spec/jobs/export_job_spec.rb
@@ -15,7 +15,9 @@ module Decidim
       let(:collection) { [proposal] } # Use an array with the instance_double
       let(:export_manifest) do
         instance_double(
-          Decidim::ComponentExportManifest,
+          # rubocop:disable RSpec/VerifiedDoubleReference
+          "Decidim::ComponentExportManifest",
+          # rubocop:enable RSpec/VerifiedDoubleReference
           name: :proposals,
           collection: ->(_component, _user, _resource_id) { collection },
           serializer: Decidim::Proposals::ProposalSerializer

--- a/spec/jobs/export_job_spec.rb
+++ b/spec/jobs/export_job_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Admin
+    describe ExportJob do
+      let!(:component) { create(:component, manifest_name: "dummy") }
+      let(:organization) { component.organization }
+      let!(:user) { create(:user, organization: organization) }
+      let!(:admin) { create(:user, :admin, organization: organization) }
+      let!(:admin_of_the_process) { create(:user, organization: organization) }
+      let!(:participatory_process) { create(:participatory_process, organization: organization) }
+      let(:proposal) { create(:proposal) }
+      let(:collection) { [proposal] } # Use an array with the instance_double
+      let(:export_manifest) do
+        instance_double(
+          Decidim::ComponentExportManifest,
+          name: :proposals,
+          collection: ->(_component, _user, _resource_id) { collection },
+          serializer: Decidim::Proposals::ProposalSerializer
+        )
+      end
+
+      before do
+        component.update!(participatory_space: participatory_process)
+        create(:participatory_process_user_role, user: admin_of_the_process, participatory_process: participatory_process, role: "admin")
+
+        allow(component.manifest).to receive(:export_manifests).and_return([export_manifest])
+      end
+
+      it "sends an email with the result of the export" do
+        ExportJob.perform_now(user, component, "proposals", "CSV")
+
+        email = last_email
+        expect(email.subject).to include("proposals")
+        attachment = email.attachments.first
+
+        expect(attachment.read.length).to be_positive
+        expect(attachment.mime_type).to eq("application/zip")
+        expect(attachment.filename).to match(/^proposals-[0-9]+-[0-9]+-[0-9]+-[0-9]+\.zip$/)
+      end
+
+      describe "CSV" do
+        it "uses the CSV exporter" do
+          export_data = double
+
+          expect(Decidim::Exporters::CSV)
+            .to(receive(:new).with(anything, Decidim::Proposals::ProposalSerializer))
+            .and_return(double(export: export_data))
+
+          expect(ExportMailer)
+            .to(receive(:export).with(user, anything, export_data))
+            .and_return(double(deliver_now: true))
+
+          ExportJob.perform_now(user, component, "proposals", "CSV")
+        end
+      end
+
+      describe "JSON" do
+        it "uses the JSON exporter" do
+          export_data = double
+
+          expect(Decidim::Exporters::JSON)
+            .to(receive(:new).with(anything, Decidim::Proposals::ProposalSerializer))
+            .and_return(double(export: export_data))
+
+          expect(ExportMailer)
+            .to(receive(:export).with(user, anything, export_data))
+            .and_return(double(deliver_now: true))
+
+          ExportJob.perform_now(user, component, "proposals", "JSON")
+        end
+      end
+
+      describe "Admin export" do
+        let(:serializer) { Decidim::Proposals::ProposalSerializer }
+
+        before do
+          allow(Decidim::Exporters::CSV)
+            .to(receive(:new).with(anything, serializer))
+            .and_return(double(export: "normal export data"))
+        end
+
+        it "allows admin to access admin_export" do
+          expect(Decidim::Exporters::CSV)
+            .to(receive(:new).with(anything, serializer))
+            .and_return(double(admin_export: "admin export data"))
+
+          expect(ExportMailer)
+            .to(receive(:export).with(admin, anything, "admin export data"))
+            .and_return(double(deliver_now: true))
+
+          ExportJob.perform_now(admin, component, "proposals", "CSV")
+        end
+
+        it "allows admin of the process to access admin_export" do
+          expect(Decidim::Exporters::CSV)
+            .to(receive(:new).with(anything, serializer))
+            .and_return(double(admin_export: "admin export data"))
+
+          expect(ExportMailer)
+            .to(receive(:export).with(admin_of_the_process, anything, "admin export data"))
+            .and_return(double(deliver_now: true))
+
+          ExportJob.perform_now(admin_of_the_process, component, "proposals", "CSV")
+        end
+
+        it "does not allow normal user to access admin_export" do
+          expect(Decidim::Exporters::CSV)
+            .to(receive(:new).with(anything, serializer))
+            .and_return(double(export: "normal export data"))
+
+          expect(ExportMailer)
+            .to(receive(:export).with(user, anything, "normal export data"))
+            .and_return(double(deliver_now: true))
+
+          ExportJob.perform_now(user, component, "proposals", "CSV")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*
This PR fixes the issue of not receiving infos from the author of a proposal when exporting as a user who's an administrator from a processes and not an administrator from the platform.

#### :pushpin: Related Issues
*Link your PR to an issue*
- [Toulouse & decidim-app - Non extraction des mails dans les exports de propositions pour les admins d’espace](https://www.notion.so/opensourcepolitics/Toulouse-decidim-app-Non-extraction-des-mails-dans-les-exports-de-propositions-pour-les-admins-d-2f782358512a4ff1a2e043d661677f99?pvs=4)

#### Testing
*Describe the best way to test or validate your PR.*

Example:
* Sign in as an admin 
* Go to a proposal component with published proposals
* Click on the export button
* See that you can view email and names of the participants

* Invite yourself as an admin of the PP or the assembly (with a different email address)
* Sign in as the space admin and go to the same proposal component
* Click on the export button
* See that you can view email and names of the participants just like the administrator of the platform

#### Tasks
- [x] Add specs
- [x] Fix little issue from Module Phone authorization handler in local that blocked the export of proposals
- [x] Extend the export job to change the behavior for a process administrator


### :camera: Screenshots
*Please add screenshots of the changes you're proposing if related to the UI*
