### PR TITLE
fix: Fix Half Signup that is not working properly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,6 @@ gem "decidim-extended_socio_demographic_authorization_handler", git: "https://gi
 gem "decidim-extra_user_fields", git: "https://github.com/OpenSourcePolitics/decidim-module-extra_user_fields.git", branch: "temp/twilio-compatibility-0.27"
 gem "decidim-friendly_signup", git: "https://github.com/OpenSourcePolitics/decidim-module-friendly_signup.git"
 gem "decidim-gallery", git: "https://github.com/OpenSourcePolitics/decidim-module-gallery.git", branch: "fix/nokogiri_deps"
-gem "decidim-half_signup", git: "https://github.com/OpenSourcePolitics/decidim-module-half_sign_up.git", branch: "feature/half_signup_and_budgets_booth"
 gem "decidim-homepage_interactive_map", git: "https://github.com/OpenSourcePolitics/decidim-module-homepage_interactive_map.git", branch: DECIDIM_BRANCH
 gem "decidim-ludens", git: "https://github.com/OpenSourcePolitics/decidim-ludens.git", branch: DECIDIM_BRANCH
 gem "decidim-phone_authorization_handler", git: "https://github.com/OpenSourcePolitics/decidim-module_phone_authorization_handler", branch: "release/0.27-stable"
@@ -32,6 +31,7 @@ gem "decidim-survey_multiple_answers", git: "https://github.com/alecslupu-pfa/de
 gem "decidim-term_customizer", git: "https://github.com/OpenSourcePolitics/decidim-module-term_customizer.git", branch: "fix/email_with_precompile"
 
 gem "decidim-budgets_booth", github: "Pipeline-to-Power/decidim-module-ptp", branch: "main"
+gem "decidim-half_signup", git: "https://github.com/OpenSourcePolitics/decidim-module-half_sign_up.git", branch: "feature/half_signup_and_budgets_booth"
 
 # Omniauth gems
 gem "omniauth-france_connect", git: "https://github.com/OpenSourcePolitics/omniauth-france_connect"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,7 @@ GIT
 
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-half_sign_up.git
-  revision: c23334e721cd9a6b1d43ae72fc9b6a4387334c9f
+  revision: 5bee2b5422e4131f933ad854ab872e049dcf7b54
   branch: feature/half_signup_and_budgets_booth
   specs:
     decidim-half_signup (0.27.0)


### PR DESCRIPTION
#### :tophat: Description
We move the gem below Budgets booth as it needs to overwrite some features of it.

#### :pushpin: Related Issues

#### Testing

Example:
* Log in as admin
* Access Backoffice
* Go to organization settings
* Go to authentication settings
* Enable Authentication using SMS on Half Signup
* Go back to front office
* Access a participatory process
* Access a budget
* Try to vote for it
* Check that you are redirected to the authentication using SMS
* Check that the behavior is working properly from beginning to end

#### Tasks
- [x] Fix gem order
- [x] Bump HalfSignup
